### PR TITLE
Refactor settings management and enhance type safety with Codable

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .watchOS(.v7),
         .tvOS(.v14),
         .macOS(.v11),
-        .visionOS(.v1)
+        .visionOS("2.0")
     ],
     products: [
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -6,10 +6,10 @@ import PackageDescription
 let package = Package(
     name: "DCSettings",
     platforms: [
-        .iOS(.v13),
-        .watchOS(.v6),
-        .tvOS(.v13),
-        .macOS(.v10_15),
+        .iOS(.v14),
+        .watchOS(.v7),
+        .tvOS(.v14),
+        .macOS(.v11),
         .visionOS(.v1)
     ],
     products: [

--- a/Sources/DCSettings/Documentation.docc/DCSettings.md
+++ b/Sources/DCSettings/Documentation.docc/DCSettings.md
@@ -4,9 +4,11 @@ DCSettings is a Swift package that simplifies the configuration of user preferen
 
 ## Overview
 
-To configure settings, you can use the `configure` method on a ``DCSettingsManager`` instance, typically the shared  singleton instance. This method takes a closure that returns an array of ``DCSettingGroup`` instances. Each ``DCSettingGroup`` can contain multiple ``DCSetting`` instances. Settings will be stored in `UserDefaults`, `NSUbiquitousKeyValueStore` or a custom key-value store depending on how they are configured. 
+To configure settings, you can use the `configure` method on a ``DCSettingsManager`` instance, typically the shared singleton instance. This method takes a closure that returns an array of ``DCSettingGroup`` instances. Each ``DCSettingGroup`` can contain multiple ``DCSetting`` instances. Settings will be stored in `UserDefaults`, `NSUbiquitousKeyValueStore` or a custom key-value store depending on how they are configured.
 
 Once your settings are set up, you can quickly add a settings view to your app using ``DCSettingsView``. This view displays a list of all the setting groups and settings that you’ve configured using the given ``DCSettingsManager``. You can create an instance of this view and add it to your app’s view hierarchy like any other SwiftUI view.
+
+> Note: The settings configuration and storage APIs support the package's minimum platform versions. ``DCSettingsView`` is available on iOS 14, macOS 11, tvOS 14, watchOS 8, and visionOS 1 or newer.
 
 *Example configuration:*
 
@@ -30,7 +32,10 @@ DCSettingsManager.shared.configure {
         DCSetting(key: "maxSyncItems", defaultValue: 1000)
     }
     DCSettingGroup("Appearance") {
-        DCSetting(key: "theme", label: "Theme", options: ["Light", "Dark"])
+        DCSetting(key: "theme", label: "Theme") {
+            DCSettingOption(value: "Light", label: "Light")
+            DCSettingOption(value: "Dark", label: "Dark")
+        }
         DCSetting(key: "fontSize", options: [12, 14, 16, 18, 20], defaultIndex: 2)
         DCSetting(key: "lineSpacing", defaultValue: 1.2, lowerBound: 1.0, upperBound: 1.6, step: 0.1)
         DCSetting(key: "highlightColor", defaultValue: Color.blue)

--- a/Sources/DCSettings/Documentation.docc/DCSettings.md
+++ b/Sources/DCSettings/Documentation.docc/DCSettings.md
@@ -8,7 +8,7 @@ To configure settings, you can use the `configure` method on a ``DCSettingsManag
 
 Once your settings are set up, you can quickly add a settings view to your app using ``DCSettingsView``. This view displays a list of all the setting groups and settings that you’ve configured using the given ``DCSettingsManager``. You can create an instance of this view and add it to your app’s view hierarchy like any other SwiftUI view.
 
-> Note: The settings configuration and storage APIs support the package's minimum platform versions. ``DCSettingsView`` is available on iOS 14, macOS 11, tvOS 14, watchOS 8, and visionOS 1 or newer.
+> Note: The settings configuration and storage APIs support the package's minimum platform versions. ``DCSettingsView`` is available on iOS 14, macOS 11, tvOS 14, watchOS 7, and visionOS 1 or newer.
 
 *Example configuration:*
 

--- a/Sources/DCSettings/Documentation.docc/DCSettings.md
+++ b/Sources/DCSettings/Documentation.docc/DCSettings.md
@@ -8,7 +8,7 @@ To configure settings, you can use the `configure` method on a ``DCSettingsManag
 
 Once your settings are set up, you can quickly add a settings view to your app using ``DCSettingsView``. This view displays a list of all the setting groups and settings that you’ve configured using the given ``DCSettingsManager``. You can create an instance of this view and add it to your app’s view hierarchy like any other SwiftUI view.
 
-> Note: The settings configuration and storage APIs support the package's minimum platform versions. ``DCSettingsView`` is available on iOS 14, macOS 11, tvOS 14, watchOS 7, and visionOS 1 or newer.
+> Note: The settings configuration and storage APIs support the package's minimum platform versions. ``DCSettingsView`` is available on iOS 14, macOS 11, tvOS 14, watchOS 7, and visionOS 2 or newer.
 
 *Example configuration:*
 

--- a/Sources/DCSettings/Extensions/Color+Codable.swift
+++ b/Sources/DCSettings/Extensions/Color+Codable.swift
@@ -14,14 +14,11 @@ import AppKit
 #endif
 
 #if compiler(>=6.0)
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
 extension Color: @retroactive Codable {}
 #else
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
 extension Color: Codable {}
 #endif
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
 extension Color {
     
     #if canImport(UIKit)

--- a/Sources/DCSettings/Extensions/Color+Codable.swift
+++ b/Sources/DCSettings/Extensions/Color+Codable.swift
@@ -13,8 +13,16 @@ import UIKit
 import AppKit
 #endif
 
+#if compiler(>=6.0)
 @available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
-extension Color: Codable {
+extension Color: @retroactive Codable {}
+#else
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+extension Color: Codable {}
+#endif
+
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+extension Color {
     
     #if canImport(UIKit)
     typealias NativeColor = UIColor

--- a/Sources/DCSettings/Settings/DCSetting.swift
+++ b/Sources/DCSettings/Settings/DCSetting.swift
@@ -180,7 +180,7 @@ public class DCSetting<ValueType>: DCSettable where ValueType: Equatable {
     ///   - key: The key used to identify the setting in the store.
     ///   - label: An optional label for the setting. The default value is `nil`.
     ///   - store: An optional `DCSettingStore` instance used to store the setting value. The default value is `nil`.
-    ///   - options: An array of `DCSettingOption` instances.
+    ///   - configuredOptions: An array of `DCSettingOption` instances.
     public convenience init?(key: DCKeyRepresentable, label: String? = nil, store: DCSettingStore? = nil, options configuredOptions: [DCSettingOption<ValueType>]) {
         if let defaultValue = configuredOptions.first(where: { $0.isDefault })?.value ?? configuredOptions.first?.value {
             self.init(key: key, value: defaultValue, label: label, configuation: DCSettingConfiguration<ValueType>(options: configuredOptions, bounds: nil, step: nil), store: store)
@@ -251,11 +251,11 @@ public class DCSetting<ValueType>: DCSettable where ValueType: Equatable {
     
     private func setUpListener() {
         guard let store = store else { return }
-        cancellable = store.valuePublisher(forKey: key)
+        cancellable = store.valuePublisher(forKey: key, as: ValueType.self)
             .receive(on: RunLoop.main)
             .sink { [weak self] newValue in
-                if let newTypedValue = newValue as? ValueType, self?.value != newTypedValue {
-                    self?.value = newTypedValue
+                if let newValue = newValue, self?.value != newValue {
+                    self?.value = newValue
                 }
             }
     }

--- a/Sources/DCSettings/Settings/DCSettingsManager.swift
+++ b/Sources/DCSettings/Settings/DCSettingsManager.swift
@@ -44,7 +44,7 @@ public class DCSettingsManager {
     
     /// Configures the manager with an array of setting groups.
     ///
-    /// - Parameter groups: An array of `DCSettingGroup` values representing the setting groups to be managed by the manager.
+    /// - Parameter settingGroups: An array of `DCSettingGroup` values representing the setting groups to be managed by the manager.
     public func configure(groups settingGroups: [DCSettingGroup]) {
         groups = settingGroups
         for group in groups {

--- a/Sources/DCSettings/Settings/DCStoredRepresentedValue.swift
+++ b/Sources/DCSettings/Settings/DCStoredRepresentedValue.swift
@@ -13,7 +13,6 @@ import SwiftUI
 /// This is useful when working with settings that have raw representable values such as enums or option sets.
 ///
 /// When the wrapped value is accessed or modified, the value will be automatically loaded from or saved to the store using a `DCSetting` instance.
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
 @propertyWrapper
 public struct DCStoredRepresentedValue<ValueType>: DynamicProperty where ValueType: RawRepresentable, ValueType.RawValue: Equatable {
     

--- a/Sources/DCSettings/Settings/DCStoredValue.swift
+++ b/Sources/DCSettings/Settings/DCStoredValue.swift
@@ -20,7 +20,6 @@ import SwiftUI
 ///
 /// @DCStoredValue("key3") var value3: Bool
 /// ```
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
 @propertyWrapper
 public struct DCStoredValue<ValueType>: DynamicProperty where ValueType: Equatable {
     

--- a/Sources/DCSettings/Store/DCSettingStore.swift
+++ b/Sources/DCSettings/Store/DCSettingStore.swift
@@ -10,15 +10,15 @@ import Combine
 /// An enumeration that represents different types of key-value stores.
 public enum DCSettingStore {
     
-    /// The standard `UserDeafults` key-value store.
+    /// The standard `UserDefaults` key-value store.
     case standard
     
-    /// A `UserDeafults` key-value store with the specified suite name.
+    /// A `UserDefaults` key-value store with the specified suite name.
     ///
-    /// - Parameter suiteName: The suite name of the `UserDeafults` store to use.
+    /// - Parameter suiteName: The suite name of the `UserDefaults` store to use.
     case userDefaults(suiteName: String)
     
-    /// A key-value store that uses the iCloud  `NSUbiquitousKeyValueStore` key-value store.
+    /// A key-value store that uses the iCloud `NSUbiquitousKeyValueStore` key-value store.
     case ubiquitous
     
     /// A custom key-value store that conforms to the `DCKeyValueStore` protocol.
@@ -56,6 +56,20 @@ public enum DCSettingStore {
         return backingStore.valuePublisher(forKey: key)
     }
     
+    /// Returns a publisher that emits the typed value for the given key whenever it changes.
+    ///
+    /// - Parameters:
+    ///   - key: The key for the value to observe.
+    ///   - type: The expected value type.
+    /// - Returns: A publisher that emits decoded typed values for the given key whenever it changes.
+    public func valuePublisher<ValueType>(forKey key: String, as type: ValueType.Type) -> AnyPublisher<ValueType?, Never> {
+        return valuePublisher(forKey: key)
+            .map { object in
+                decodedValue(object, as: type)
+            }
+            .eraseToAnyPublisher()
+    }
+    
     /// Sets the value of the specified key in the key-value store.
     ///
     /// - Parameters:
@@ -75,19 +89,7 @@ public enum DCSettingStore {
     /// - Parameter key: A key in the key-value store.
     /// - Returns: The value associated with the specified key, or `nil` if the key does not exist.
     public func object<ValueType>(forKey key: String) -> ValueType? {
-        if case .custom = self {
-            return backingStore.object(forKey: key) as? ValueType
-        }
-        
-        let object = backingStore.object(forKey: key)
-        if isStandardType(ValueType.self) {
-            return backingStore.object(forKey: key) as? ValueType
-        }
-        else if let data = object as? Data, let decodableType = ValueType.self as? Decodable.Type {
-            let value = try? JSONDecoder().decode(decodableType, from: data)
-            return value as? ValueType
-        }
-        return nil
+        return decodedValue(backingStore.object(forKey: key), as: ValueType.self)
     }
     
     /// Sets a boolean value for the specified key in the key-value store.
@@ -152,5 +154,18 @@ public enum DCSettingStore {
     
     private func isStandardType<T>(_ type: T.Type) -> Bool {
         return type == Bool.self || type == Int.self || type == Double.self || type == String.self || type == Date.self || type == Data.self
+    }
+    
+    private func decodedValue<ValueType>(_ object: Any?, as type: ValueType.Type) -> ValueType? {
+        if let value = object as? ValueType {
+            return value
+        }
+        
+        if let data = object as? Data, let decodableType = ValueType.self as? Decodable.Type {
+            let value = try? JSONDecoder().decode(decodableType, from: data)
+            return value as? ValueType
+        }
+        
+        return nil
     }
 }

--- a/Sources/DCSettings/Views/DCSettingView.swift
+++ b/Sources/DCSettings/Views/DCSettingView.swift
@@ -24,7 +24,6 @@ enum DCOptionControlStyle: Equatable {
 
 extension DCSettingOption {
     
-    @available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
     public func labelView() -> some View {
         return HStack {
             if let string = label {
@@ -52,7 +51,6 @@ extension DCSettingOption {
     }
 }
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 struct DCBoolSettingView: View {
     @Environment(\.isEnabled) var isEnabled
     
@@ -69,7 +67,6 @@ struct DCBoolSettingView: View {
     }
 }
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 struct DCIntSettingView: View {
     @Environment(\.isEnabled) var isEnabled
     
@@ -153,7 +150,6 @@ struct DCIntSettingView: View {
     }
 }
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 struct DCDoubleSettingView: View {
     @Environment(\.isEnabled) var isEnabled
     
@@ -193,7 +189,6 @@ struct DCDoubleSettingView: View {
     }
 }
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 struct DCStringSettingView: View {
     @Environment(\.isEnabled) var isEnabled
     
@@ -235,7 +230,6 @@ struct DCStringSettingView: View {
     }
 }
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 struct DCDateSettingView: View {
     @Environment(\.isEnabled) var isEnabled
     
@@ -264,7 +258,6 @@ struct DCDateSettingView: View {
     }
 }
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 struct DCColorSettingView: View {
     @Environment(\.isEnabled) var isEnabled
     
@@ -282,7 +275,6 @@ struct DCColorSettingView: View {
     }
 }
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 struct DCSliderView: View {
     @Environment(\.isEnabled) var isEnabled
     
@@ -346,7 +338,6 @@ struct DCSliderView: View {
     }
 }
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 struct DCMenuPickerView<ValueType>: View where ValueType: Equatable & Hashable {
     @Environment(\.isEnabled) var isEnabled
     
@@ -416,7 +407,6 @@ struct DCMenuPickerView<ValueType>: View where ValueType: Equatable & Hashable {
 /// If no specific view is available for the value type, the view will be empty.
 ///
 /// Supported types are: `Bool`, `Int`,  `Double`, `String`, `Date` and `Color`.
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 public struct DCSettingView: View {
     
     private let setting: any DCSettable
@@ -452,7 +442,6 @@ public struct DCSettingView: View {
     }
 }
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 struct DCSettingView_Previews: PreviewProvider {
 
     static var previews: some View {

--- a/Sources/DCSettings/Views/DCSettingView.swift
+++ b/Sources/DCSettings/Views/DCSettingView.swift
@@ -13,6 +13,15 @@ extension DCSetting {
     }
 }
 
+enum DCOptionControlStyle: Equatable {
+    case picker
+    case menuPicker
+    
+    init(optionCount: Int) {
+        self = optionCount > 2 ? .menuPicker : .picker
+    }
+}
+
 extension DCSettingOption {
     
     @available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
@@ -68,7 +77,7 @@ struct DCIntSettingView: View {
     
     var body: some View {
         if let options = setting.configuation?.options {
-            if options.count > 2 {
+            if DCOptionControlStyle(optionCount: options.count) == .menuPicker {
                 DCMenuPickerView(key: setting.key, label: setting.displayLabel, options: options, value: $setting.value)
             }
             else {
@@ -99,7 +108,7 @@ struct DCIntSettingView: View {
                 Double(setting.value)
             }, set: { newValue in
                 setting.value = Int(newValue)
-            }), bounds: DCValueBounds(lowerBound: Double(bounds.lowerBound), upperBound: Double(bounds.upperBound)), step: Double(setting.configuation?.step ?? 0), specifier: "%.0f")
+            }), bounds: DCValueBounds(lowerBound: Double(bounds.lowerBound), upperBound: Double(bounds.upperBound)), step: setting.configuation?.step.map { Double($0) }, specifier: "%.0f")
         }
         else {
             HStack {
@@ -108,9 +117,36 @@ struct DCIntSettingView: View {
                 Spacer()
                 Text(String(setting.value))
                     .padding(.trailing, 8.0)
-                Stepper(setting.displayLabel, value: $setting.value)
-                    .labelsHidden()
-                    .accessibilityIdentifier(setting.key)
+                #if os(watchOS)
+                    if #available(watchOS 9.0, *) {
+                        Stepper(setting.displayLabel, value: $setting.value)
+                            .labelsHidden()
+                            .accessibilityIdentifier(setting.key)
+                    }
+                    else {
+                        HStack(spacing: 8.0) {
+                            Button {
+                                setting.value -= 1
+                            } label: {
+                                Image(systemName: "minus")
+                            }
+                            .accessibilityLabel("Decrease \(setting.displayLabel)")
+                            .accessibilityIdentifier("\(setting.key).decrement")
+                            
+                            Button {
+                                setting.value += 1
+                            } label: {
+                                Image(systemName: "plus")
+                            }
+                            .accessibilityLabel("Increase \(setting.displayLabel)")
+                            .accessibilityIdentifier("\(setting.key).increment")
+                        }
+                    }
+                #else
+                    Stepper(setting.displayLabel, value: $setting.value)
+                        .labelsHidden()
+                        .accessibilityIdentifier(setting.key)
+                #endif
             }
             .foregroundColor(isEnabled ? .primary : .secondary)
         }
@@ -119,11 +155,37 @@ struct DCIntSettingView: View {
 
 @available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 struct DCDoubleSettingView: View {
+    @Environment(\.isEnabled) var isEnabled
+    
     @ObservedObject var setting: DCSetting<Double>
     
     var body: some View {
-        if let options = setting.configuation?.options, options.count > 2 {
-            DCMenuPickerView(key: setting.key, label: setting.displayLabel, options: options, value: $setting.value)
+        if let options = setting.configuation?.options {
+            if DCOptionControlStyle(optionCount: options.count) == .menuPicker {
+                DCMenuPickerView(key: setting.key, label: setting.displayLabel, options: options, value: $setting.value)
+            }
+            else {
+                HStack {
+                    Text(setting.displayLabel)
+                    Spacer(minLength: 16.0)
+                    Picker(setting.displayLabel, selection: $setting.value) {
+                        ForEach(options, id: \.value) { option in
+                            option.labelView()
+                                .tag(option.value)
+                        }
+                    }
+                    .labelsHidden()
+                    .accessibilityIdentifier(setting.key)
+                    #if os(macOS)
+                        .pickerStyle(RadioGroupPickerStyle())
+                        .horizontalRadioGroupLayout()
+                    #elseif !os(watchOS)
+                        .pickerStyle(SegmentedPickerStyle())
+                        .frame(maxWidth: 140.0)
+                    #endif
+                }
+                .foregroundColor(isEnabled ? .primary : .secondary)
+            }
         }
         else {
             DCSliderView(key: setting.key, label: setting.displayLabel, value: $setting.value, bounds: setting.configuation?.bounds, step: setting.configuation?.step, specifier: "%.2f")
@@ -139,7 +201,7 @@ struct DCStringSettingView: View {
     
     var body: some View {
         if let options = setting.configuation?.options {
-            if options.count > 2 {
+            if DCOptionControlStyle(optionCount: options.count) == .menuPicker {
                 DCMenuPickerView(key: setting.key, label: setting.displayLabel, options: options, value: $setting.value)
             }
             else {
@@ -185,7 +247,7 @@ struct DCDateSettingView: View {
             Text(setting.displayLabel)
         #else
             if let bounds = setting.configuation?.bounds {
-                DatePicker(selection: $setting.value, in: bounds.upperBound...bounds.upperBound, displayedComponents: .date) {
+                DatePicker(selection: $setting.value, in: bounds.lowerBound...bounds.upperBound, displayedComponents: .date) {
                     Text(setting.displayLabel)
                 }
                 .foregroundColor(isEnabled ? .primary : .secondary)

--- a/Sources/DCSettings/Views/DCSettingsView.swift
+++ b/Sources/DCSettings/Views/DCSettingsView.swift
@@ -14,7 +14,6 @@ import SwiftUI
 /// The view uses a `DCSettingViewProviding` instance to provide custom views for individual settings.
 /// If no custom view is available for a specific setting, a default view will be used if the setting's value is a supported type.
 /// Supported types as standard are: `Bool`, `Int`, `Double`, `String`, `Date` and `Color`.
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 public struct DCSettingsView<Provider: DCSettingViewProviding, S: ListStyle>: View {
     
     /// An enumeration that defines the available filters for the settings view.
@@ -80,7 +79,6 @@ public struct DCSettingsView<Provider: DCSettingViewProviding, S: ListStyle>: Vi
     }
 }
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 extension DCSettingsView where Provider == DCDefaultViewProvider {
     
     /// Initializes a new settings view with the default content provider and the specified list style.
@@ -90,7 +88,6 @@ extension DCSettingsView where Provider == DCDefaultViewProvider {
 }
 
 #if os(macOS)
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 extension DCSettingsView where S == SidebarListStyle {
     
     /// Initializes a new settings view with the platform default list style.
@@ -99,7 +96,6 @@ extension DCSettingsView where S == SidebarListStyle {
     }
 }
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 extension DCSettingsView where Provider == DCDefaultViewProvider, S == SidebarListStyle {
     
     /// Initializes a new settings view with the default content provider and platform default list style.
@@ -108,7 +104,6 @@ extension DCSettingsView where Provider == DCDefaultViewProvider, S == SidebarLi
     }
 }
 #elseif os(watchOS)
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 extension DCSettingsView where S == DefaultListStyle {
     
     /// Initializes a new settings view with the platform default list style.
@@ -117,7 +112,6 @@ extension DCSettingsView where S == DefaultListStyle {
     }
 }
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 extension DCSettingsView where Provider == DCDefaultViewProvider, S == DefaultListStyle {
     
     /// Initializes a new settings view with the default content provider and platform default list style.
@@ -126,7 +120,6 @@ extension DCSettingsView where Provider == DCDefaultViewProvider, S == DefaultLi
     }
 }
 #else
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 extension DCSettingsView where S == InsetGroupedListStyle {
     
     /// Initializes a new settings view with the platform default list style.
@@ -135,7 +128,6 @@ extension DCSettingsView where S == InsetGroupedListStyle {
     }
 }
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 extension DCSettingsView where Provider == DCDefaultViewProvider, S == InsetGroupedListStyle {
     
     /// Initializes a new settings view with the default content provider and platform default list style.
@@ -145,7 +137,6 @@ extension DCSettingsView where Provider == DCDefaultViewProvider, S == InsetGrou
 }
 #endif
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 struct DCSettingsView_Previews: PreviewProvider {
 
     static var previews: some View {

--- a/Sources/DCSettings/Views/DCSettingsView.swift
+++ b/Sources/DCSettings/Views/DCSettingsView.swift
@@ -42,30 +42,20 @@ public struct DCSettingsView<Provider: DCSettingViewProviding, S: ListStyle>: Vi
     /// Initializes a new `DCSettingsView` instance with the specified settings manager, filter, and content provider.
     ///
     /// This initializer creates a new instance of `DCSettingsView` with the specified settings manager, filter, and content provider.
-    /// The settings manager is required, while the filter and content provider are optional.
+    /// The settings manager is required, while the filter is optional.
     ///
     /// - Parameters:
     ///   - settingsManager: A `DCSettingsManager` instance used to manage the settings.
     ///   The default value is the `.shared` singleton instance.
     ///   - filter: A `Filter` value used to filter the displayed settings. The default value is `nil`.
     ///   - contentProvider: A `DCSettingViewProviding` instance used to provide custom views for individual settings.
-    ///   The default value is an instance of `DCDefaultViewProvider`.
-    ///   - listStyle: A `ListStyle` value used to set the style of the list. The default value is platform-dependent.
-    #if os(macOS)
-        public init(settingsManager: DCSettingsManager = .shared, filter: Filter? = nil, contentProvider: Provider? = DCDefaultViewProvider(), listStyle: S = SidebarListStyle()) {
-            self.settingsManager = settingsManager
-            self.filter = filter
-            self.contentProvider = contentProvider
-            self.listStyle = listStyle
-        }
-    #else
-        public init(settingsManager: DCSettingsManager = .shared, filter: Filter? = nil, contentProvider: Provider? = DCDefaultViewProvider(), listStyle: S = InsetGroupedListStyle()) {
-            self.settingsManager = settingsManager
-            self.filter = filter
-            self.contentProvider = contentProvider
-            self.listStyle = listStyle
-        }
-    #endif
+    ///   - listStyle: A `ListStyle` value used to set the style of the list.
+    public init(settingsManager: DCSettingsManager = .shared, filter: Filter? = nil, contentProvider: Provider?, listStyle: S) {
+        self.settingsManager = settingsManager
+        self.filter = filter
+        self.contentProvider = contentProvider
+        self.listStyle = listStyle
+    }
     
     public var body: some View {
         List(settingsManager.groups) { group in
@@ -89,6 +79,71 @@ public struct DCSettingsView<Provider: DCSettingViewProviding, S: ListStyle>: Vi
         .listStyle(listStyle)
     }
 }
+
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
+extension DCSettingsView where Provider == DCDefaultViewProvider {
+    
+    /// Initializes a new settings view with the default content provider and the specified list style.
+    public init(settingsManager: DCSettingsManager = .shared, filter: Filter? = nil, listStyle: S) {
+        self.init(settingsManager: settingsManager, filter: filter, contentProvider: DCDefaultViewProvider(), listStyle: listStyle)
+    }
+}
+
+#if os(macOS)
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
+extension DCSettingsView where S == SidebarListStyle {
+    
+    /// Initializes a new settings view with the platform default list style.
+    public init(settingsManager: DCSettingsManager = .shared, filter: Filter? = nil, contentProvider: Provider?) {
+        self.init(settingsManager: settingsManager, filter: filter, contentProvider: contentProvider, listStyle: SidebarListStyle())
+    }
+}
+
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
+extension DCSettingsView where Provider == DCDefaultViewProvider, S == SidebarListStyle {
+    
+    /// Initializes a new settings view with the default content provider and platform default list style.
+    public init(settingsManager: DCSettingsManager = .shared, filter: Filter? = nil) {
+        self.init(settingsManager: settingsManager, filter: filter, contentProvider: DCDefaultViewProvider(), listStyle: SidebarListStyle())
+    }
+}
+#elseif os(watchOS)
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
+extension DCSettingsView where S == DefaultListStyle {
+    
+    /// Initializes a new settings view with the platform default list style.
+    public init(settingsManager: DCSettingsManager = .shared, filter: Filter? = nil, contentProvider: Provider?) {
+        self.init(settingsManager: settingsManager, filter: filter, contentProvider: contentProvider, listStyle: DefaultListStyle())
+    }
+}
+
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
+extension DCSettingsView where Provider == DCDefaultViewProvider, S == DefaultListStyle {
+    
+    /// Initializes a new settings view with the default content provider and platform default list style.
+    public init(settingsManager: DCSettingsManager = .shared, filter: Filter? = nil) {
+        self.init(settingsManager: settingsManager, filter: filter, contentProvider: DCDefaultViewProvider(), listStyle: DefaultListStyle())
+    }
+}
+#else
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
+extension DCSettingsView where S == InsetGroupedListStyle {
+    
+    /// Initializes a new settings view with the platform default list style.
+    public init(settingsManager: DCSettingsManager = .shared, filter: Filter? = nil, contentProvider: Provider?) {
+        self.init(settingsManager: settingsManager, filter: filter, contentProvider: contentProvider, listStyle: InsetGroupedListStyle())
+    }
+}
+
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
+extension DCSettingsView where Provider == DCDefaultViewProvider, S == InsetGroupedListStyle {
+    
+    /// Initializes a new settings view with the default content provider and platform default list style.
+    public init(settingsManager: DCSettingsManager = .shared, filter: Filter? = nil) {
+        self.init(settingsManager: settingsManager, filter: filter, contentProvider: DCDefaultViewProvider(), listStyle: InsetGroupedListStyle())
+    }
+}
+#endif
 
 @available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 struct DCSettingsView_Previews: PreviewProvider {

--- a/Tests/DCSettingsTests/DCSettingGroupTests.swift
+++ b/Tests/DCSettingsTests/DCSettingGroupTests.swift
@@ -28,4 +28,38 @@ class DCSettingGroupTests: XCTestCase {
     func testSettings() {
         XCTAssertEqual(group.settings.count, 2)
     }
+    
+    func testKeyLabelAndID() {
+        let group = DCSettingGroup(key: "general", label: "General", store: store, settings: [setting1])
+        
+        XCTAssertEqual(group.key, "general")
+        XCTAssertEqual(group.id, "general")
+        XCTAssertEqual(group.label, "General")
+    }
+    
+    func testLabelInitializerCreatesGroupWithSettings() {
+        let group = DCSettingGroup("General", store: store, settings: [setting1, setting2])
+        
+        XCTAssertEqual(group.label, "General")
+        XCTAssertEqual(group.settings.count, 2)
+    }
+    
+    func testStoreModifierReturnsCopyWithNewStore() {
+        let newStore = DCSettingStore.custom(backingStore: MockStore())
+        
+        let updatedGroup = group.store(newStore)
+        
+        XCTAssertEqual(updatedGroup.key, group.key)
+        XCTAssertEqual(updatedGroup.label, group.label)
+        XCTAssertEqual(updatedGroup.settings.count, group.settings.count)
+    }
+    
+    func testGroupsBuilderBuildsGroups() {
+        let groups = DCSettingGroupsBuilder.buildBlock(
+            DCSettingGroup("General", settings: [setting1]),
+            DCSettingGroup("Appearance", settings: [setting2])
+        )
+        
+        XCTAssertEqual(groups.map(\.label), ["General", "Appearance"])
+    }
 }

--- a/Tests/DCSettingsTests/DCSettingOptionTests.swift
+++ b/Tests/DCSettingsTests/DCSettingOptionTests.swift
@@ -9,6 +9,23 @@ import XCTest
 
 final class DCSettingOptionTests: XCTestCase {
     
+    private enum TestOption: String, DCSettingOptionProviding {
+        case first
+        case second
+        
+        static var defaultCase: TestOption? {
+            return .second
+        }
+        
+        var label: String? {
+            return rawValue.sentenceFormatted
+        }
+        
+        var image: DCImageName? {
+            return .system(rawValue)
+        }
+    }
+    
     func testEquatable() {
         let option1 = DCSettingOption(value: "Value1", label: "Label1", image: "Image1")
         let option2 = DCSettingOption(value: "Value1", label: "Label1", image: "Image1")
@@ -41,5 +58,41 @@ final class DCSettingOptionTests: XCTestCase {
     func testDefaultOption() {
         let option = DCSettingOption(value: "Value", default: true)
         XCTAssertTrue(option.isDefault)
+    }
+    
+    func testDefaultModifierReturnsDefaultOption() {
+        let option = DCSettingOption(value: "Value", label: "Label").default()
+        
+        XCTAssertTrue(option.isDefault)
+        XCTAssertEqual(option.label, "Label")
+        XCTAssertEqual(option.value, "Value")
+    }
+    
+    func testImageOnlyInitializers() {
+        let customImageOption = DCSettingOption(value: "Value", image: "Image")
+        let systemImageOption = DCSettingOption(value: "Value", systemImage: "SystemImage")
+        
+        XCTAssertNil(customImageOption.label)
+        XCTAssertEqual(customImageOption.image, .custom("Image"))
+        XCTAssertNil(systemImageOption.label)
+        XCTAssertEqual(systemImageOption.image, .system("SystemImage"))
+    }
+    
+    func testDefaultOptionProvidingImplementations() {
+        XCTAssertNil(StringDefaultOption.defaultCase)
+        XCTAssertNil(StringDefaultOption.sample.label)
+        XCTAssertNil(StringDefaultOption.sample.image)
+    }
+    
+    func testOptionsProviderInitializerUsesProviderMetadata() {
+        let setting = DCSetting(key: "optionProvider", optionsProvider: TestOption.self)
+        
+        XCTAssertEqual(setting?.value, TestOption.second.rawValue)
+        XCTAssertEqual(setting?.configuation?.options?.first?.label, "First")
+        XCTAssertEqual(setting?.configuation?.options?.first?.image, .system("first"))
+    }
+    
+    private enum StringDefaultOption: String, DCSettingOptionProviding {
+        case sample
     }
 }

--- a/Tests/DCSettingsTests/DCSettingTests.swift
+++ b/Tests/DCSettingsTests/DCSettingTests.swift
@@ -6,18 +6,26 @@
 
 import XCTest
 @testable import DCSettings
+import Combine
 
 final class DCSettingTests: XCTestCase {
+    
+    private struct CodableValue: Codable, Equatable {
+        let name: String
+        let count: Int
+    }
 
     private var store: DCSettingStore!
     private var backingStore: MockStore!
     private var setting: DCSetting<String>!
+    private var cancellables: Set<AnyCancellable> = []
     
     override func setUp() {
         super.setUp()
         backingStore = MockStore()
         store = .custom(backingStore: backingStore)
         setting = DCSetting(key: "testKey", defaultValue: "defaultValue", store: store)
+        cancellables = []
     }
     
     func testInitWithDefaultValue() {
@@ -62,5 +70,39 @@ final class DCSettingTests: XCTestCase {
         setting.value = "newValue"
         
         XCTAssertEqual(backingStore?.storage["testKey"] as? String, setting.value)
+    }
+    
+    func testCodableCustomStoreRefreshRoundTrip() {
+        let storedValue = CodableValue(name: "stored", count: 42)
+        let defaultValue = CodableValue(name: "default", count: 0)
+        let setting = DCSetting(key: "codableKey", defaultValue: defaultValue, store: store)
+        
+        setting.value = storedValue
+        
+        XCTAssertTrue(backingStore.storage["codableKey"] is Data)
+        
+        let refreshedSetting = DCSetting(key: "codableKey", defaultValue: defaultValue, store: store)
+        refreshedSetting.refresh()
+        
+        XCTAssertEqual(refreshedSetting.value, storedValue)
+    }
+    
+    func testCodableCustomStorePublisherRoundTrip() {
+        let defaultValue = CodableValue(name: "default", count: 0)
+        let updatedValue = CodableValue(name: "updated", count: 7)
+        let setting = DCSetting(key: "codableKey", defaultValue: defaultValue, store: store)
+        let valueDidChange = expectation(description: "Codable value update was decoded")
+        
+        setting.refresh()
+        setting.objectWillChange
+            .sink {
+                valueDidChange.fulfill()
+            }
+            .store(in: &cancellables)
+        
+        store.set(updatedValue, forKey: "codableKey")
+        
+        wait(for: [valueDidChange], timeout: 1.0)
+        XCTAssertEqual(setting.value, updatedValue)
     }
 }

--- a/Tests/DCSettingsTests/DCSettingViewTests.swift
+++ b/Tests/DCSettingsTests/DCSettingViewTests.swift
@@ -1,0 +1,35 @@
+//
+//  DCSettings
+//  Copyright (c) David Caddy 2023
+//  MIT license, see LICENSE file for details
+//
+
+import XCTest
+@testable import DCSettings
+
+final class DCSettingViewTests: XCTestCase {
+    
+    func testDisplayLabelUsesExplicitLabel() {
+        let setting = DCSetting(key: "articleListLayout", defaultValue: true, label: "Layout")
+        
+        XCTAssertEqual(setting.displayLabel, "Layout")
+    }
+    
+    func testDisplayLabelFormatsKeyWhenLabelIsMissing() {
+        let setting = DCSetting(key: "articleListLayout", defaultValue: true)
+        
+        XCTAssertEqual(setting.displayLabel, "Article list layout")
+    }
+    
+    func testOptionControlStyleUsesPickerForTwoOrFewerOptions() {
+        XCTAssertEqual(DCOptionControlStyle(optionCount: 0), .picker)
+        XCTAssertEqual(DCOptionControlStyle(optionCount: 1), .picker)
+        XCTAssertEqual(DCOptionControlStyle(optionCount: 2), .picker)
+    }
+    
+    func testOptionControlStyleUsesMenuPickerForMoreThanTwoOptions() {
+        XCTAssertEqual(DCOptionControlStyle(optionCount: 3), .menuPicker)
+        XCTAssertEqual(DCOptionControlStyle(optionCount: 10), .menuPicker)
+    }
+}
+

--- a/Tests/DCSettingsTests/DCSettingsViewTests.swift
+++ b/Tests/DCSettingsTests/DCSettingsViewTests.swift
@@ -1,0 +1,48 @@
+//
+//  DCSettings
+//  Copyright (c) David Caddy 2023
+//  MIT license, see LICENSE file for details
+//
+
+import XCTest
+import SwiftUI
+@testable import DCSettings
+
+final class DCSettingsViewTests: XCTestCase {
+    
+    private struct CustomViewProvider: DCSettingViewProviding {
+        func content(for setting: any DCSettable) -> Text? {
+            return nil
+        }
+    }
+    
+    func testDefaultInitializerUsesDefaultProviderAndPlatformListStyle() {
+        #if os(macOS)
+            let view: DCSettingsView<DCDefaultViewProvider, SidebarListStyle> = DCSettingsView()
+        #elseif os(watchOS)
+            let view: DCSettingsView<DCDefaultViewProvider, DefaultListStyle> = DCSettingsView()
+        #else
+            let view: DCSettingsView<DCDefaultViewProvider, InsetGroupedListStyle> = DCSettingsView()
+        #endif
+        
+        XCTAssertNotNil(view)
+    }
+    
+    func testCustomProviderInitializerUsesPlatformListStyle() {
+        #if os(macOS)
+            let view: DCSettingsView<CustomViewProvider, SidebarListStyle> = DCSettingsView(contentProvider: CustomViewProvider())
+        #elseif os(watchOS)
+            let view: DCSettingsView<CustomViewProvider, DefaultListStyle> = DCSettingsView(contentProvider: CustomViewProvider())
+        #else
+            let view: DCSettingsView<CustomViewProvider, InsetGroupedListStyle> = DCSettingsView(contentProvider: CustomViewProvider())
+        #endif
+        
+        XCTAssertNotNil(view)
+    }
+    
+    func testCustomListStyleInitializerUsesDefaultProvider() {
+        let view: DCSettingsView<DCDefaultViewProvider, PlainListStyle> = DCSettingsView(listStyle: PlainListStyle())
+        
+        XCTAssertNotNil(view)
+    }
+}

--- a/Tests/DCSettingsTests/DCStorageConvenienceTests.swift
+++ b/Tests/DCSettingsTests/DCStorageConvenienceTests.swift
@@ -1,0 +1,116 @@
+//
+//  DCSettings
+//  Copyright (c) David Caddy 2023
+//  MIT license, see LICENSE file for details
+//
+
+import XCTest
+import SwiftUI
+import Combine
+@testable import DCSettings
+
+final class DCStorageConvenienceTests: XCTestCase {
+    
+    private enum TestMode: String {
+        case list
+        case grid
+    }
+    
+    private struct ColorComponents: Codable {
+        let red: CGFloat
+        let green: CGFloat
+        let blue: CGFloat
+        let opacity: CGFloat
+    }
+    
+    private var cancellables: Set<AnyCancellable> = []
+    
+    override func tearDown() {
+        cancellables = []
+        super.tearDown()
+    }
+    
+    func testColorCodableRoundTrip() throws {
+        let components = ColorComponents(red: 0.25, green: 0.5, blue: 0.75, opacity: 0.6)
+        let color = Color(red: components.red, green: components.green, blue: components.blue, opacity: components.opacity)
+        
+        let encodedColor = try JSONEncoder().encode(color)
+        let decodedColor = try JSONDecoder().decode(Color.self, from: encodedColor)
+        let encodedDecodedColor = try JSONEncoder().encode(decodedColor)
+        let decodedComponents = try JSONDecoder().decode(ColorComponents.self, from: encodedDecodedColor)
+        
+        XCTAssertEqual(decodedComponents.red, components.red, accuracy: 0.001)
+        XCTAssertEqual(decodedComponents.green, components.green, accuracy: 0.001)
+        XCTAssertEqual(decodedComponents.blue, components.blue, accuracy: 0.001)
+        XCTAssertEqual(decodedComponents.opacity, components.opacity, accuracy: 0.001)
+    }
+    
+    func testUserDefaultsValuePublisherEmitsInitialAndChangedValue() {
+        let suiteName = "DCStorageConvenienceTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        let valueDidChange = expectation(description: "UserDefaults value changed")
+        var receivedValues: [String?] = []
+        
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+        
+        defaults.valuePublisher(forKey: "layout")
+            .sink { value in
+                receivedValues.append(value as? String)
+                if receivedValues.count == 2 {
+                    valueDidChange.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+        
+        defaults.set("grid", forKey: "layout")
+        
+        wait(for: [valueDidChange], timeout: 1.0)
+        XCTAssertEqual(receivedValues, [nil, "grid"])
+    }
+    
+    func testStoredValueReadsAndWritesConfiguredSetting() {
+        let manager = DCSettingsManager()
+        let backingStore = MockStore()
+        
+        manager.configure {
+            DCSettingGroup("Display", store: .custom(backingStore: backingStore)) {
+                DCSetting(key: "title", defaultValue: "Initial")
+            }
+        }
+        
+        let storedValue = DCStoredValue<String>("title", settingsManager: manager)
+        
+        XCTAssertEqual(storedValue.wrappedValue, "Initial")
+        
+        storedValue.wrappedValue = "Updated"
+        
+        XCTAssertEqual(manager.string(forKey: "title"), "Updated")
+        XCTAssertEqual(backingStore.storage["title"] as? String, "Updated")
+    }
+    
+    func testStoredRepresentedValueReadsAndWritesRawRepresentableSetting() {
+        let manager = DCSettingsManager()
+        let backingStore = MockStore()
+        
+        manager.configure {
+            DCSettingGroup("Display", store: .custom(backingStore: backingStore)) {
+                DCSetting(key: "mode", defaultValue: TestMode.list.rawValue)
+            }
+        }
+        
+        let storedValue = DCStoredRepresentedValue<TestMode>("mode", settingsManager: manager)
+        
+        XCTAssertEqual(storedValue.wrappedValue, .list)
+        
+        storedValue.wrappedValue = .grid
+        
+        XCTAssertEqual(manager.string(forKey: "mode"), TestMode.grid.rawValue)
+        XCTAssertEqual(backingStore.storage["mode"] as? String, TestMode.grid.rawValue)
+        
+        storedValue.wrappedValue = nil
+        
+        XCTAssertEqual(manager.string(forKey: "mode"), TestMode.grid.rawValue)
+    }
+}

--- a/Tests/DCSettingsTests/StringExtendedTests.swift
+++ b/Tests/DCSettingsTests/StringExtendedTests.swift
@@ -1,0 +1,23 @@
+//
+//  DCSettings
+//  Copyright (c) David Caddy 2023
+//  MIT license, see LICENSE file for details
+//
+
+import XCTest
+@testable import DCSettings
+
+final class StringExtendedTests: XCTestCase {
+    
+    func testSentenceCapitalizedLowercasesRemainingCharacters() {
+        XCTAssertEqual("hELLO WORLD".sentenceCapitalized, "Hello world")
+    }
+    
+    func testSentenceFormattedReplacesUnderscoresAndCamelCase() {
+        XCTAssertEqual("great_userSetting2".sentenceFormatted, "Great user setting 2")
+    }
+    
+    func testSentenceFormattedTrimsLeadingWhitespaceFromAcronyms() {
+        XCTAssertEqual("URLScheme".sentenceFormatted, "Urlscheme")
+    }
+}

--- a/Tests/DCSettingsTests/StringExtendedTests.swift
+++ b/Tests/DCSettingsTests/StringExtendedTests.swift
@@ -17,7 +17,7 @@ final class StringExtendedTests: XCTestCase {
         XCTAssertEqual("great_userSetting2".sentenceFormatted, "Great user setting 2")
     }
     
-    func testSentenceFormattedTrimsLeadingWhitespaceFromAcronyms() {
+    func testSentenceFormattedFormatsAcronymCamelCaseInput() {
         XCTAssertEqual("URLScheme".sentenceFormatted, "Urlscheme")
     }
 }


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the DCSettings package, focusing on enhancing type safety, platform compatibility, API flexibility, and user interface consistency. The most significant changes include improvements to type handling in settings storage and publishers, more flexible and platform-adaptive initializers for `DCSettingsView`, and UI/UX enhancements for option and stepper controls, especially on watchOS.

**Type handling and API improvements:**

* Added a generic, type-safe `valuePublisher(forKey:as:)` method and a `decodedValue` helper to `DCSettingStore`, improving how values are decoded and published from storage. This change also refactors the `object(forKey:)` method to use the new decoding logic for consistency and reliability. [[1]](diffhunk://#diff-2022494550142f03756bda11ffddc58c5512068ec3a7ea091ade226a814ae599R59-R72) [[2]](diffhunk://#diff-2022494550142f03756bda11ffddc58c5512068ec3a7ea091ade226a814ae599L78-R92) [[3]](diffhunk://#diff-2022494550142f03756bda11ffddc58c5512068ec3a7ea091ade226a814ae599R158-R170)
* Updated `DCSetting` to use the new typed publisher from the store, simplifying the value update logic and ensuring type correctness.

**SwiftUI and platform compatibility:**

* Refactored `DCSettingsView` initializers to be more flexible and platform-adaptive, allowing for easier usage of default providers and list styles across different platforms (macOS, watchOS, others). [[1]](diffhunk://#diff-1337e00092603010ba5b75900ee37bcf370e2e61f90b21f7134408be6087df0aL45-L68) [[2]](diffhunk://#diff-1337e00092603010ba5b75900ee37bcf370e2e61f90b21f7134408be6087df0aR83-R147)
* Improved the documentation to clarify platform availability and updated API parameter names for clarity and consistency. [[1]](diffhunk://#diff-71c4c2edb1ef2b432f2aad2473c24ed0f2c532be7f341a5ebf6f121bd6433ac0R11-R12) [[2]](diffhunk://#diff-ba0e784db5da14f42362c2e43a18e28ad3baf3f1e93f28f37320296d94c04ed5L47-R47) [[3]](diffhunk://#diff-1337e00092603010ba5b75900ee37bcf370e2e61f90b21f7134408be6087df0aL45-L68)

**User interface and UX enhancements:**

* Introduced a `DCOptionControlStyle` enum to standardize when to use pickers vs. menu pickers based on option count, and refactored option controls in setting views to use this logic for consistency. [[1]](diffhunk://#diff-2906d1a192a0da88b07e7f4ea697c93a4541259d0eeac867ebb004b336ff9350R16-R24) [[2]](diffhunk://#diff-2906d1a192a0da88b07e7f4ea697c93a4541259d0eeac867ebb004b336ff9350L71-R80) [[3]](diffhunk://#diff-2906d1a192a0da88b07e7f4ea697c93a4541259d0eeac867ebb004b336ff9350L142-R204)
* Enhanced the handling of integer and double setting views, including improved support for stepper controls on watchOS (with custom fallback UI for older versions), correct step handling, and improved accessibility. [[1]](diffhunk://#diff-2906d1a192a0da88b07e7f4ea697c93a4541259d0eeac867ebb004b336ff9350L102-R111) [[2]](diffhunk://#diff-2906d1a192a0da88b07e7f4ea697c93a4541259d0eeac867ebb004b336ff9350R120-R189)
* Fixed an issue with date picker bounds in `DCDateSettingView` to use the correct lower and upper bounds.

**Other notable improvements:**

* Improved Codable conformance for `Color` with support for future Swift compilers.
* Corrected typos in documentation related to `UserDefaults`.
* Updated the API for defining option settings to use a more flexible closure-based syntax in documentation examples.
* Renamed parameters for clarity in the `DCSetting` and `DCSettingsManager` APIs. [[1]](diffhunk://#diff-ff7b13d4c8c2b1bd8419baef7156c1fe2a459f37280bc2b7e166d71bc8cc90c1L183-R183) [[2]](diffhunk://#diff-ba0e784db5da14f42362c2e43a18e28ad3baf3f1e93f28f37320296d94c04ed5L47-R47)