### PR TITLE
Refactor settings management, improve type safety, and enhance tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ DCSettings 1.0 stabilizes the public API after the beta period.
 - Supports Codable setting values by storing them as JSON-encoded `Data`.
 - De-duplicates unchanged UserDefaults publisher values and ignores unrelated ubiquitous-store key changes.
 - Refines default settings controls, option pickers, date ranges, and platform list styles.
-- Expands package tests around storage, publishers, setting views, options, and string formatting.
+- Migrates the package test suite to Swift Testing and expands coverage around storage, publishers, setting views, options, and string formatting.
 
 ### Migration Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ DCSettings 1.0 stabilizes the public API after the beta period.
 
 - Adds `configuration` as the correctly spelled setting configuration property.
 - Keeps the misspelled `configuation` property as deprecated compatibility API.
-- Builds in Swift 6 language mode with explicit main-actor isolation for the settings UI state layer.
+- Builds in Swift 6 language mode with explicit main-actor isolation for manager, setting, property-wrapper, and settings-view APIs.
 - Emits current values immediately from manager value publishers.
 - Supports Codable setting values by storing them as JSON-encoded `Data`.
 - De-duplicates unchanged UserDefaults publisher values and ignores unrelated ubiquitous-store key changes.
@@ -24,5 +24,6 @@ DCSettings 1.0 stabilizes the public API after the beta period.
 ### Migration Notes
 
 - If you previously read `configuation`, move to `configuration`.
+- Configure, read, and write settings through `DCSettingsManager` from the main actor.
 - Custom `DCKeyValueStore` implementations should accept `Data` values to support custom Codable setting types.
-- Values that are neither property-list compatible nor `Encodable` are not persisted.
+- Values that are neither property-list compatible nor `Codable` are not persisted.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ DCSettings 1.0 stabilizes the public API after the beta period.
 
 ### Requirements
 
-- Requires Swift 5.9 or newer.
+- Requires Swift 6.0 or newer.
 - Supports iOS 14, macOS 11, tvOS 14, watchOS 7, and visionOS 2 or newer.
 - `DCSettingStore.ubiquitous` requires watchOS 9 or newer.
 
@@ -14,6 +14,7 @@ DCSettings 1.0 stabilizes the public API after the beta period.
 
 - Adds `configuration` as the correctly spelled setting configuration property.
 - Keeps the misspelled `configuation` property as deprecated compatibility API.
+- Builds in Swift 6 language mode with explicit main-actor isolation for the settings UI state layer.
 - Emits current values immediately from manager value publishers.
 - Supports Codable setting values by storing them as JSON-encoded `Data`.
 - De-duplicates unchanged UserDefaults publisher values and ignores unrelated ubiquitous-store key changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ DCSettings 1.0 stabilizes the public API after the beta period.
 - Keeps the misspelled `configuation` property as deprecated compatibility API.
 - Builds in Swift 6 language mode with explicit main-actor isolation for manager, setting, property-wrapper, and settings-view APIs.
 - Emits current values immediately from manager value publishers.
-- Supports Codable setting values by storing them as JSON-encoded `Data`.
+- Supports Color and Codable setting values by storing them as JSON-encoded `Data`.
 - De-duplicates unchanged UserDefaults publisher values and ignores unrelated ubiquitous-store key changes.
+- Adds `if`/`switch`/`for` control-flow support to settings result builders.
 - Refines default settings controls, option pickers, date ranges, and platform list styles.
 - Migrates the package test suite to Swift Testing and expands coverage around storage, publishers, setting views, options, and string formatting.
 
@@ -26,4 +27,4 @@ DCSettings 1.0 stabilizes the public API after the beta period.
 - If you previously read `configuation`, move to `configuration`.
 - Configure, read, and write settings through `DCSettingsManager` from the main actor.
 - Custom `DCKeyValueStore` implementations should accept `Data` values to support custom Codable setting types.
-- Values that are neither property-list compatible nor `Codable` are not persisted.
+- Values that are neither property-list compatible nor `Color` or `Codable` are not persisted.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+## 1.0.0 - Unreleased
+
+DCSettings 1.0 stabilizes the public API after the beta period.
+
+### Requirements
+
+- Requires Swift 5.9 or newer.
+- Supports iOS 14, macOS 11, tvOS 14, watchOS 7, and visionOS 2 or newer.
+- `DCSettingStore.ubiquitous` requires watchOS 9 or newer.
+
+### Highlights
+
+- Adds `configuration` as the correctly spelled setting configuration property.
+- Keeps the misspelled `configuation` property as deprecated compatibility API.
+- Emits current values immediately from manager value publishers.
+- Supports Codable setting values by storing them as JSON-encoded `Data`.
+- De-duplicates unchanged UserDefaults publisher values and ignores unrelated ubiquitous-store key changes.
+- Refines default settings controls, option pickers, date ranges, and platform list styles.
+- Expands package tests around storage, publishers, setting views, options, and string formatting.
+
+### Migration Notes
+
+- If you previously read `configuation`, move to `configuration`.
+- Custom `DCKeyValueStore` implementations should accept `Data` values to support custom Codable setting types.
+- Values that are neither property-list compatible nor `Encodable` are not persisted.

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -26,5 +26,6 @@ let package = Package(
         .testTarget(
             name: "DCSettingsTests",
             dependencies: ["DCSettings"]),
-    ]
+    ],
+    swiftLanguageModes: [.v6]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .watchOS(.v7),
         .tvOS(.v14),
         .macOS(.v11),
-        .visionOS(.v1)
+        .visionOS("2.0")
     ],
     products: [
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -6,10 +6,10 @@ import PackageDescription
 let package = Package(
     name: "DCSettings",
     platforms: [
-        .iOS(.v13),
-        .watchOS(.v6),
-        .tvOS(.v13),
-        .macOS(.v10_15),
+        .iOS(.v14),
+        .watchOS(.v7),
+        .tvOS(.v14),
+        .macOS(.v11),
         .visionOS(.v1)
     ],
     products: [

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ dependencies: [
 
 DCSettings requires Swift 6.0 or newer and supports iOS 14, macOS 11, tvOS 14, watchOS 7, and visionOS 2 or newer. `DCSettingStore.ubiquitous` requires watchOS 9 or newer.
 
+`DCSettingsManager`, `DCSetting`, the stored-value property wrappers, and the SwiftUI settings views are main-actor isolated. Configure, read, and write settings through `DCSettingsManager` from the main actor. The lower-level `DCSettingStore` and `DCKeyValueStore` storage APIs remain actor-neutral.
+
 ## Usage
 
 To use `DCSettings` in your project, you’ll need to import it at the top of your Swift file like so:
@@ -87,7 +89,7 @@ import DCSettings
 
 ## Configuring Settings
 
-To configure settings, you can use the `configure` method on a `DCSettingsManager` instance, typically the shared singleton instance. This method takes a closure that returns an array of `DCSettingGroup` instances. Each `DCSettingGroup` can contain multiple `DCSetting` instances.
+To configure settings, use the `configure` method on a `DCSettingsManager` instance, typically the shared singleton instance. `DCSettingsManager` is main-actor isolated, so call `configure` from the main actor. This method takes a closure that returns an array of `DCSettingGroup` instances. Each `DCSettingGroup` can contain multiple `DCSetting` instances.
 
 Here’s an example of how you might configure your settings:
 
@@ -196,7 +198,7 @@ DCSettingsManager.shared.configure {
 
 ### Storage contract
 
-DCSettings stores property-list compatible values (`Bool`, `Int`, `Double`, `String`, `Date`, and `Data`) directly in the selected backing store. Other values must conform to `Codable`; they are JSON-encoded to `Data` before storage and decoded when read back. Values that are neither property-list compatible nor `Encodable` are rejected in debug builds with an assertion and are not persisted.
+DCSettings stores property-list compatible values (`Bool`, `Int`, `Double`, `String`, `Date`, and `Data`) directly in the selected backing store. Other values must conform to `Codable`; they are JSON-encoded to `Data` before storage and decoded when read back. Values that are neither property-list compatible nor `Codable` are rejected in debug builds with an assertion and are not persisted.
 
 Custom `DCKeyValueStore` implementations should accept `Data` values if they need to support custom `Codable` setting types.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-    <img src="https://img.shields.io/badge/Swift-5.9-orange.svg" />
+    <img src="https://img.shields.io/badge/Swift-6.0-orange.svg" />
     <a href="https://swift.org/package-manager">
         <img src="https://img.shields.io/badge/swiftpm-compatible-brightgreen.svg?style=flat" alt="Swift Package Manager" />
     </a>
@@ -75,7 +75,7 @@ dependencies: [
 
 ### Requirements
 
-DCSettings requires Swift 5.9 or newer and supports iOS 14, macOS 11, tvOS 14, watchOS 7, and visionOS 2 or newer. `DCSettingStore.ubiquitous` requires watchOS 9 or newer.
+DCSettings requires Swift 6.0 or newer and supports iOS 14, macOS 11, tvOS 14, watchOS 7, and visionOS 2 or newer. `DCSettingStore.ubiquitous` requires watchOS 9 or newer.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ When configuring your settings you have several options available to you. First,
 
 > It is recommended to avoid setting-specific keys for groups.
 
-Within each `DCSettingGroup`, you can create `DCSetting` instances to represent individual settings. Each `DCSetting` has a key, a default value, and an optional label. The key is used to uniquely identify the setting, while the default value is used as the initial value for the setting if no value has been previously set. The label is used to provide a human-readable name for the setting. If no label is provided, a sentence cased string version of the key will be used as the label.
+Within each `DCSettingGroup`, you can create `DCSetting` instances to represent individual settings. Each `DCSetting` has a key, a default value, and an optional label. The key is used to uniquely identify the setting, while the default value is used as the initial value for the setting if no value has been previously set. The label is used to provide a human-readable name for the setting. If no label is provided, a sentence-cased string version of the key will be used as the label.
 
 > Note: `DCSetting` supports the following types by default: `Bool`, `Int`, `Double`, `String`, `Date`, and `Color` (SwiftUI). You can also use custom types when they conform to `Codable`.
 
@@ -155,16 +155,16 @@ In this example, we’ve created a setting group for general settings and added 
 
 ## Accessing Settings
 
-Once you’ve configured your settings, you can access them elsewhere using the `DCStoredValue` property wrapper. Here’s an example of how you might access the ShowNotifications setting from the previous example:
+Once you’ve configured your settings, you can access them elsewhere using the `DCStoredValue` property wrapper. Here’s an example of how you might access the `showNotifications` setting from the previous example:
 
 ```swift
-@DCStoredValue("ShowNotifications") var showNotifications: Bool
+@DCStoredValue("showNotifications") var showNotifications: Bool
 ```
 
-You can also access settings directly using the `DCSettingsManager` `value(forKey:)` method. Here’s an example of how you might do this:
+You can also access settings directly using `DCSettingsManager` convenience methods. Here’s an example of how you might do this:
 
 ```swift
-let showNotifications = DCSettingsManager.shared.bool(forKey: "ShowNotifications")
+let showNotifications = DCSettingsManager.shared.bool(forKey: "showNotifications")
 ```
 
 ## Backing Stores
@@ -176,7 +176,7 @@ Here’s an example that shows how to use a custom key-value store backed by a `
 ```swift
 DCSettingsManager.shared.configure {
     DCSettingGroup(key: "General") {
-        DCSetting(key: "ShowNotifications", defaultValue: true)
+        DCSetting(key: "showNotifications", defaultValue: true)
     }
     .store(.userDefaults(suiteName: "com.example.myapp"))
 }
@@ -189,7 +189,7 @@ You can also specify a custom key-value store for individual settings. Here’s 
 ```swift
 DCSettingsManager.shared.configure {
     DCSettingGroup(key: "General") {
-        DCSetting(key: "ShowNotifications", defaultValue: true, store: .userDefaults(suiteName: "com.example.myapp"))
+        DCSetting(key: "showNotifications", defaultValue: true, store: .userDefaults(suiteName: "com.example.myapp"))
     }
 }
 ```
@@ -198,7 +198,7 @@ DCSettingsManager.shared.configure {
 
 ### Storage contract
 
-DCSettings stores property-list compatible values (`Bool`, `Int`, `Double`, `String`, `Date`, and `Data`) directly in the selected backing store. Other values must conform to `Codable`; they are JSON-encoded to `Data` before storage and decoded when read back. Values that are neither property-list compatible nor `Codable` are rejected in debug builds with an assertion and are not persisted.
+DCSettings stores property-list compatible values (`Bool`, `Int`, `Double`, `String`, `Date`, and `Data`) directly in the selected backing store. `Color` values are handled as a built-in type and stored as JSON-encoded `Data`. Other values must conform to `Codable`; they are JSON-encoded to `Data` before storage and decoded when read back. Values that are neither property-list compatible nor `Color` or `Codable` are rejected in debug builds with an assertion and are not persisted.
 
 Custom `DCKeyValueStore` implementations should accept `Data` values if they need to support custom `Codable` setting types.
 
@@ -209,8 +209,8 @@ Custom `DCKeyValueStore` implementations should accept `Data` values if they nee
 ```swift
 DCSettingsManager.shared.configure {
     DCSettingGroup(key: "General") {
-        DCSetting(key: "ShowNotifications", defaultValue: true)
-        DCSetting(key: "SoundEffects", defaultValue: true)
+        DCSetting(key: "showNotifications", defaultValue: true)
+        DCSetting(key: "soundEffects", defaultValue: true)
     }
     .store(.ubiquitous)
 }
@@ -230,7 +230,7 @@ struct ContentView: View {
 }
 ```
 
-> Note: By default, `DCSettingsView` will display **all** settings. If you want to display settings only settings that have a label, you can set the filter parameter to `.labelled`.
+> Note: By default, `DCSettingsView` will display **all** settings. If you want to display only settings that have a label, set the filter parameter to `.labelled`.
 
 `DCSettingsView` has several customization options available. For example, you can specify a filter to include or exclude certain setting groups or individual settings. You can also provide a custom content provider to control how each setting is displayed.
 
@@ -262,7 +262,7 @@ When configuring a `DCSetting`, you can provide several additional options that 
 - `label`: The label property allows you to specify a human-readable name for the setting. This label is displayed next to the control for the setting within the `DCSettingsView`.
 - `image`: The image property allows you to specify the name of an image to display next to the label for the setting within the `DCSettingsView`. This image should be included in your app’s asset catalog.
 - `systemImage`: The systemImage property allows you to specify the name of a system-provided image to display next to the label for the setting within the `DCSettingsView`. This image should be one of the system-provided SF Symbols.
-- `valueBounds`: The value bounds property allows you to specify a range of valid values for the setting. If you provide value bounds for a setting, the control for that setting within the `DCSettingsView` will be constrained to only allow values within that range. For example, if you provide value bounds for a numeric setting, the control for that setting will be a slider that only allows values within the specified range.
+- `bounds`: The bounds configuration allows you to specify a range of valid values for the setting. If you provide bounds for a setting, the control for that setting within the `DCSettingsView` will be constrained to only allow values within that range. For example, if you provide bounds for a numeric setting, the control for that setting will be a slider that only allows values within the specified range.
 - `step`: The step property allows you to specify the increment between valid values for a numeric setting. If you provide a step value for a numeric setting, the control for that setting within the `DCSettingsView` will only allow values that are multiples of the step value.
 
 ### DCSettingViewProviding
@@ -275,15 +275,17 @@ Here’s an example that shows how you might create a custom `DCSettingViewProvi
 
 ```swift
 struct MySettingViewProvider: DCSettingViewProviding {
-    @ViewBuilder func content(for setting: any DCSettable) -> some View {
-        if setting.key == "ShowNotifications", let concreteSetting = setting as? DCSetting<Bool> {
-            Toggle("Show Notifications", isOn: concreteSetting.valueBinding())
+    func content(for setting: any DCSettable) -> AnyView? {
+        if setting.key == "showNotifications", let concreteSetting = setting as? DCSetting<Bool> {
+            return AnyView(Toggle("Show Notifications", isOn: concreteSetting.valueBinding()))
         }
+
+        return nil
     }
 }
 ```
 
-In this example, we’ve created a `MySettingViewProvider` type that conforms to the `DCSettingViewProviding` protocol. In our implementation of the `content(for:)` method, we’re checking if the key of the setting is "ShowNotifications" and is a setting with a `Bool` value type. If it is, we’re returning a custom toggle view for the setting. For all other settings, we’re returning `nil`, which means that the default view for those settings will be used.
+In this example, we’ve created a `MySettingViewProvider` type that conforms to the `DCSettingViewProviding` protocol. In our implementation of the `content(for:)` method, we’re checking if the key of the setting is "showNotifications" and is a setting with a `Bool` value type. If it is, we’re returning a custom toggle view for the setting. For all other settings, we’re returning `nil`, which means that the default view for those settings will be used.
 
 Once you’ve created your custom `DCSettingViewProviding` type, you can pass an instance of it to the `DCSettingsView` initializer to use it. Here’s an example that shows how you might do this:
 
@@ -297,6 +299,6 @@ struct ContentView: View {
 
 ## Contributions
 
-Before you start using **DCSettings**, it’s recommended you spend a few minutes familiarizing yourself with its documentation. Since this is a very young project, it’s likely to have some rough edges. Please do send through feedback on any issues you encounter.
+Before you start using **DCSettings**, it’s recommended you spend a few minutes familiarizing yourself with its documentation. Please do send through feedback on any issues you encounter.
 
 Depending on scope and direction your contributions are more than welcome. If you wish to make a change, please open a Pull Request - even if just a rough draft of the proposed changes - and we can discuss it further.

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 </p>
 
 <p align="center">
-    <img src="https://img.shields.io/badge/Swift-5.7-orange.svg" />
+    <img src="https://img.shields.io/badge/Swift-5.9-orange.svg" />
     <a href="https://swift.org/package-manager">
         <img src="https://img.shields.io/badge/swiftpm-compatible-brightgreen.svg?style=flat" alt="Swift Package Manager" />
     </a>
-     <img src="https://img.shields.io/badge/platforms-iOS+macOS-brightgreen.svg?style=flat" alt="iOS | Mac" />
+     <img src="https://img.shields.io/badge/platforms-iOS+macOS+tvOS+watchOS+visionOS-brightgreen.svg?style=flat" alt="iOS | macOS | tvOS | watchOS | visionOS" />
     <a href="https://mastodon.social/@caddy">
         <img src="https://img.shields.io/badge/Mastodon-@caddy-blue.svg?style=flat" alt="Mastodon: @caddy" />
     </a>
@@ -15,7 +15,7 @@
 
 Welcome to **DCSettings**, a Swift package that simplifies the configuration of user preferences with an easy-to-use result builder syntax and a drop-in SwiftUI user interface.
 
-You can configure settings in `UserDeafults`, `NSUbiquitousKeyValueStore` or a custom key-value store, like so: 
+You can configure settings in `UserDefaults`, `NSUbiquitousKeyValueStore` or a custom key-value store, like so:
 
 ```swift
 DCSettingsManager.shared.configure {
@@ -37,8 +37,17 @@ DCSettingsManager.shared.configure {
         DCSetting(key: "maxSyncItems", defaultValue: 1000)
     }
     DCSettingGroup("Appearance") {
-        DCSetting(key: "theme", label: "Theme", options: ["Light", "Dark"])
-        DCSetting(key: "fontSize", options: [12, 14, 16, 18, 20], defaultIndex: 2)
+        DCSetting(key: "theme", label: "Theme") {
+            DCSettingOption(value: "Light", label: "Light")
+            DCSettingOption(value: "Dark", label: "Dark")
+        }
+        DCSetting(key: "fontSize", label: "Font Size") {
+            DCSettingOption(value: 12, label: "12 pt")
+            DCSettingOption(value: 14, label: "14 pt")
+            DCSettingOption(value: 16, label: "16 pt").default()
+            DCSettingOption(value: 18, label: "18 pt")
+            DCSettingOption(value: 20, label: "20 pt")
+        }
         DCSetting(key: "lineSpacing", defaultValue: 1.2, lowerBound: 1.0, upperBound: 1.6, step: 0.1)
         DCSetting(key: "highlightColor", defaultValue: Color.blue)
     }
@@ -60,9 +69,13 @@ To install **DCSettings**, add the following line to your `Package.swift` file:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/davidcaddy/DCSettings.git", from: "0.1.0")
+    .package(url: "https://github.com/davidcaddy/DCSettings.git", from: "1.0.0")
 ]
 ```
+
+### Requirements
+
+DCSettings requires Swift 5.9 or newer and supports iOS 14, macOS 11, tvOS 14, watchOS 7, and visionOS 2 or newer. `DCSettingStore.ubiquitous` requires watchOS 9 or newer.
 
 ## Usage
 
@@ -74,7 +87,7 @@ import DCSettings
 
 ## Configuring Settings
 
-To configure settings, you can use the `configure` method on an `DCSettingsManager` instance, typically the shared  singleton instance. This method takes a closure that returns an array of `DCSettingGroup` instances. Each `DCSettingGroup` can contain multiple `DCSetting` instances.
+To configure settings, you can use the `configure` method on a `DCSettingsManager` instance, typically the shared singleton instance. This method takes a closure that returns an array of `DCSettingGroup` instances. Each `DCSettingGroup` can contain multiple `DCSetting` instances.
 
 Here’s an example of how you might configure your settings:
 
@@ -83,7 +96,7 @@ DCSettingsManager.shared.configure {
     DCSettingGroup("General") {
         DCSetting(key: "showNotifications", defaultValue: true)
         DCSetting(key: "soundEffects", defaultValue: true)
-        DCSetting(key: "shemeColor") {
+        DCSetting(key: "themeColor") {
             DCSettingOption(value: "Blue")
             DCSettingOption(value: "Red")
             DCSettingOption(value: "Green")
@@ -97,17 +110,17 @@ DCSettingsManager.shared.configure {
 }
 ```
 
-When configuring your settings you have several options available to you. First, you can create `DCSettingGroup` instances to group related settings together. Each `DCSettingGroup` can have a key and a label. The label is used to provide a human-readable name for the group. 
+When configuring your settings you have several options available to you. First, you can create `DCSettingGroup` instances to group related settings together. Each `DCSettingGroup` can have a key and a label. The label is used to provide a human-readable name for the group.
 
-> It is recommended to avoid settings sepecfic keys for groups.
+> It is recommended to avoid setting-specific keys for groups.
 
 Within each `DCSettingGroup`, you can create `DCSetting` instances to represent individual settings. Each `DCSetting` has a key, a default value, and an optional label. The key is used to uniquely identify the setting, while the default value is used as the initial value for the setting if no value has been previously set. The label is used to provide a human-readable name for the setting. If no label is provided, a sentence cased string version of the key will be used as the label.
 
-> Note: `DCSetting` supports the following types by default: `Bool`, `Int`, `Double`, `String`, `Date`, and `Color` (SwiftUI). You can also use custom types as they conform to the `Codable` protocol.
+> Note: `DCSetting` supports the following types by default: `Bool`, `Int`, `Double`, `String`, `Date`, and `Color` (SwiftUI). You can also use custom types when they conform to `Codable`.
 
 In addition to these basic properties, `DCSetting` instances can also have additional configuration options. These options are specified using the `DCSettingConfiguration` struct.
 
-One of the options available in `DCSettingConfiguration` is the options property. This property allows you to specify an array of `DCSettingOption` instances that represent the list valid values for the setting. Each `DCSettingOption` has a value and can also have an optional label and image.
+One of the options available in `DCSettingConfiguration` is the options property. This property allows you to specify an array of `DCSettingOption` instances that represent the valid values for the setting. Each `DCSettingOption` has a value and can also have an optional label and image.
 
 Another configuration option available in `DCSettingConfiguration` is the bounds property. This property allows you to specify a range of valid values for the setting using a `DCValueBounds` instance. A `DCValueBounds` instance has a lower bound and an upper bound that define the range of valid values.
 
@@ -123,12 +136,20 @@ DCSettingsManager.shared.configure {
             DCSettingOption(value: "Red")
             DCSettingOption(value: "Green")
         }
-        DCSetting(key: "fontSize", defaultValue: 14, lowerBound: 10, upperBound: 20, step: 2)
+        DCSetting(key: "fontSize", label: "Font Size") {
+            DCSettingOption(value: 10, label: "10 pt")
+            DCSettingOption(value: 12, label: "12 pt")
+            DCSettingOption(value: 14, label: "14 pt").default()
+            DCSettingOption(value: 16, label: "16 pt")
+            DCSettingOption(value: 18, label: "18 pt")
+            DCSettingOption(value: 20, label: "20 pt")
+        }
+        DCSetting(key: "lineSpacing", defaultValue: 1.2, lowerBound: 1.0, upperBound: 1.6, step: 0.1)
     }
 }
 ```
 
-In this example, we’ve created a setting group for general settings and added two settings: one for the theme color and one for the font size. The theme color setting has three options: blue (the default), red, and green. The font size setting has a default value of 14 and a range of valid values from 10 to 20, with a step value of 2.
+In this example, we’ve created a setting group for general settings and added three settings: one for the theme color, one for the font size, and one for line spacing. The theme color and font size settings use explicit options, while the line spacing setting has a range of valid values from 1.0 to 1.6 with a step value of 0.1.
 
 ## Accessing Settings
 
@@ -146,7 +167,7 @@ let showNotifications = DCSettingsManager.shared.bool(forKey: "ShowNotifications
 
 ## Backing Stores
 
-**DCSettings** allows you to specify which key-value store to use for each setting group and individual setting. By default, settings use the standard  key-value store, which is backed by `UserDefaults.standard`. However, you can specify a different key-value store by using the *store* property of a `DCSettingGroup` or `DCSetting`.
+**DCSettings** allows you to specify which key-value store to use for each setting group and individual setting. By default, settings use the standard key-value store, which is backed by `UserDefaults.standard`. However, you can specify a different key-value store by using the *store* property of a `DCSettingGroup` or `DCSetting`.
 
 Here’s an example that shows how to use a custom key-value store backed by a `UserDefaults` instance with the suite name "com.example.myapp".
 
@@ -173,7 +194,15 @@ DCSettingsManager.shared.configure {
 
 > Note: If you specify a custom key-value store for a setting group, all settings within that group will use that key-value store, unless you specify a different key-value store for an individual setting.
 
+### Storage contract
+
+DCSettings stores property-list compatible values (`Bool`, `Int`, `Double`, `String`, `Date`, and `Data`) directly in the selected backing store. Other values must conform to `Codable`; they are JSON-encoded to `Data` before storage and decoded when read back. Values that are neither property-list compatible nor `Encodable` are rejected in debug builds with an assertion and are not persisted.
+
+Custom `DCKeyValueStore` implementations should accept `Data` values if they need to support custom `Codable` setting types.
+
 **DCSettings** also supports using `NSUbiquitousKeyValueStore` as a key-value store for your settings, which is a key-value store that stores data in iCloud, allowing settings to be shared across multiple devices. Here’s an example that shows how to use `NSUbiquitousKeyValueStore` for a setting group:
+
+> Note: `DCSettingStore.ubiquitous` requires watchOS 9 or newer. The rest of the settings configuration and storage APIs support the package's minimum platform versions.
 
 ```swift
 DCSettingsManager.shared.configure {
@@ -219,7 +248,7 @@ When you use a `DCSettingsView` to display your settings, each setting will be p
 
 - `Bool`: Settings with a Bool value type are presented as a toggle switch. The user can tap the switch to turn the setting on or off.
 - `Int`: Settings with an Int value type are presented in several different ways depending on their configuration. If the setting has options, it will be presented as a segmented control or a popover menu, depending on the number of options. If the setting has value bounds, it will be presented as a slider. Otherwise, it will be presented as a stepper control.
-- `Double`: Settings with an Int value type are presented in several different ways depending on their configuration. If the setting has options, it will be presented as a segmented control or a popover menu, depending on the number of options. Otherwiseit will be presented as a slider. The user can drag the slider to adjust the value of the setting.
+- `Double`: Settings with a Double value type are presented in several different ways depending on their configuration. If the setting has options, it will be presented as a segmented control or a popover menu, depending on the number of options. Otherwise, it will be presented as a slider. The user can drag the slider to adjust the value of the setting.
 - `String`: Settings with a String value type are presented in several different ways depending on their configuration. If the setting has options, it will be presented as a segmented control or a menu, depending on the number of options. Otherwise, it will be presented as a text field.
 - `Date`: Settings with a Date value type are presented as a date picker. The user can tap the date picker to choose a date.
 - `Color`: Settings with a Color value type are presented as a color picker. The user can tap the color picker to choose a color.
@@ -238,7 +267,7 @@ When configuring a `DCSetting`, you can provide several additional options that 
 
 `DCSettingViewProviding` is a protocol that allows you to provide custom views for individual settings within a `DCSettingsView`. To use this protocol, you’ll need to create a type that conforms to it and implement the `content(for:)` method.
 
-The `content(for:)` method takes a `DCSettable` instance as its argument and returns an optional view. If you return a view from this method, it will be used when ppresenting the setting to the user. If you return `nil`, the default view for the setting will be used.
+The `content(for:)` method takes a `DCSettable` instance as its argument and returns an optional view. If you return a view from this method, it will be used when presenting the setting to the user. If you return `nil`, the default view for the setting will be used.
 
 Here’s an example that shows how you might create a custom `DCSettingViewProviding` type:
 

--- a/Sources/DCSettings/Documentation.docc/DCSettings.md
+++ b/Sources/DCSettings/Documentation.docc/DCSettings.md
@@ -4,9 +4,11 @@ DCSettings is a Swift package that simplifies the configuration of user preferen
 
 ## Overview
 
-To configure settings, you can use the `configure` method on a ``DCSettingsManager`` instance, typically the shared  singleton instance. This method takes a closure that returns an array of ``DCSettingGroup`` instances. Each ``DCSettingGroup`` can contain multiple ``DCSetting`` instances. Settings will be stored in `UserDefaults`, `NSUbiquitousKeyValueStore` or a custom key-value store depending on how they are configured. 
+To configure settings, you can use the `configure` method on a ``DCSettingsManager`` instance, typically the shared singleton instance. This method takes a closure that returns an array of ``DCSettingGroup`` instances. Each ``DCSettingGroup`` can contain multiple ``DCSetting`` instances. Settings will be stored in `UserDefaults`, `NSUbiquitousKeyValueStore` or a custom key-value store depending on how they are configured.
 
 Once your settings are set up, you can quickly add a settings view to your app using ``DCSettingsView``. This view displays a list of all the setting groups and settings that you’ve configured using the given ``DCSettingsManager``. You can create an instance of this view and add it to your app’s view hierarchy like any other SwiftUI view.
+
+> Note: The settings configuration and storage APIs support the package's minimum platform versions. ``DCSettingsView`` is available on iOS 14, macOS 11, tvOS 14, watchOS 8, and visionOS 1 or newer.
 
 *Example configuration:*
 
@@ -30,7 +32,10 @@ DCSettingsManager.shared.configure {
         DCSetting(key: "maxSyncItems", defaultValue: 1000)
     }
     DCSettingGroup("Appearance") {
-        DCSetting(key: "theme", label: "Theme", options: ["Light", "Dark"])
+        DCSetting(key: "theme", label: "Theme") {
+            DCSettingOption(value: "Light", label: "Light")
+            DCSettingOption(value: "Dark", label: "Dark")
+        }
         DCSetting(key: "fontSize", options: [12, 14, 16, 18, 20], defaultIndex: 2)
         DCSetting(key: "lineSpacing", defaultValue: 1.2, lowerBound: 1.0, upperBound: 1.6, step: 0.1)
         DCSetting(key: "highlightColor", defaultValue: Color.blue)

--- a/Sources/DCSettings/Documentation.docc/DCSettings.md
+++ b/Sources/DCSettings/Documentation.docc/DCSettings.md
@@ -8,7 +8,7 @@ To configure settings, you can use the `configure` method on a ``DCSettingsManag
 
 Once your settings are set up, you can quickly add a settings view to your app using ``DCSettingsView``. This view displays a list of all the setting groups and settings that you’ve configured using the given ``DCSettingsManager``. You can create an instance of this view and add it to your app’s view hierarchy like any other SwiftUI view.
 
-> Note: The settings configuration and storage APIs support the package's minimum platform versions. ``DCSettingsView`` is available on iOS 14, macOS 11, tvOS 14, watchOS 8, and visionOS 1 or newer.
+> Note: The settings configuration and storage APIs support the package's minimum platform versions. ``DCSettingsView`` is available on iOS 14, macOS 11, tvOS 14, watchOS 7, and visionOS 1 or newer.
 
 *Example configuration:*
 

--- a/Sources/DCSettings/Documentation.docc/DCSettings.md
+++ b/Sources/DCSettings/Documentation.docc/DCSettings.md
@@ -8,7 +8,7 @@ To configure settings, you can use the `configure` method on a ``DCSettingsManag
 
 Once your settings are set up, you can quickly add a settings view to your app using ``DCSettingsView``. This view displays a list of all the setting groups and settings that you’ve configured using the given ``DCSettingsManager``. You can create an instance of this view and add it to your app’s view hierarchy like any other SwiftUI view.
 
-> Note: The settings configuration and storage APIs support the package's minimum platform versions. ``DCSettingsView`` is available on iOS 14, macOS 11, tvOS 14, watchOS 7, and visionOS 1 or newer.
+> Note: The settings configuration and storage APIs support the package's minimum platform versions. ``DCSettingsView`` is available on iOS 14, macOS 11, tvOS 14, watchOS 7, and visionOS 2 or newer.
 
 *Example configuration:*
 

--- a/Sources/DCSettings/Documentation.docc/DCSettings.md
+++ b/Sources/DCSettings/Documentation.docc/DCSettings.md
@@ -12,7 +12,7 @@ Once your settings are set up, you can quickly add a settings view to your app u
 
 > Note: ``DCSettingsManager``, ``DCSetting``, the stored-value property wrappers, and the SwiftUI settings views are main-actor isolated. The lower-level ``DCSettingStore`` and ``DCKeyValueStore`` storage APIs remain actor-neutral.
 
-DCSettings stores property-list compatible values (`Bool`, `Int`, `Double`, `String`, `Date`, and `Data`) directly in the selected backing store. Other values must conform to `Codable`; they are JSON-encoded to `Data` before storage and decoded when read back. Values that are neither property-list compatible nor `Codable` are rejected in debug builds with an assertion and are not persisted. Custom ``DCKeyValueStore`` implementations should accept `Data` values to support custom `Codable` setting types.
+DCSettings stores property-list compatible values (`Bool`, `Int`, `Double`, `String`, `Date`, and `Data`) directly in the selected backing store. `Color` values are handled as a built-in type and stored as JSON-encoded `Data`. Other values must conform to `Codable`; they are JSON-encoded to `Data` before storage and decoded when read back. Values that are neither property-list compatible nor `Color` or `Codable` are rejected in debug builds with an assertion and are not persisted. Custom ``DCKeyValueStore`` implementations should accept `Data` values to support custom `Codable` setting types.
 
 *Example configuration:*
 

--- a/Sources/DCSettings/Documentation.docc/DCSettings.md
+++ b/Sources/DCSettings/Documentation.docc/DCSettings.md
@@ -8,7 +8,7 @@ To configure settings, you can use the `configure` method on a ``DCSettingsManag
 
 Once your settings are set up, you can quickly add a settings view to your app using ``DCSettingsView``. This view displays a list of all the setting groups and settings that you’ve configured using the given ``DCSettingsManager``. You can create an instance of this view and add it to your app’s view hierarchy like any other SwiftUI view.
 
-> Note: The settings configuration and storage APIs support the package's minimum platform versions. ``DCSettingsView`` is available on iOS 14, macOS 11, tvOS 14, watchOS 7, and visionOS 2 or newer.
+> Note: The settings configuration and storage APIs support the package's minimum platform versions, except ``DCSettingStore/ubiquitous`` requires watchOS 9 or newer. ``DCSettingsView`` is available on iOS 14, macOS 11, tvOS 14, watchOS 7, and visionOS 2 or newer.
 
 *Example configuration:*
 

--- a/Sources/DCSettings/Documentation.docc/DCSettings.md
+++ b/Sources/DCSettings/Documentation.docc/DCSettings.md
@@ -4,13 +4,15 @@ DCSettings is a Swift package that simplifies the configuration of user preferen
 
 ## Overview
 
-To configure settings, you can use the `configure` method on a ``DCSettingsManager`` instance, typically the shared singleton instance. This method takes a closure that returns an array of ``DCSettingGroup`` instances. Each ``DCSettingGroup`` can contain multiple ``DCSetting`` instances. Settings will be stored in `UserDefaults`, `NSUbiquitousKeyValueStore` or a custom key-value store depending on how they are configured.
+To configure settings, use the `configure` method on a ``DCSettingsManager`` instance, typically the shared singleton instance. ``DCSettingsManager`` is main-actor isolated, so call `configure` from the main actor. This method takes a closure that returns an array of ``DCSettingGroup`` instances. Each ``DCSettingGroup`` can contain multiple ``DCSetting`` instances. Settings will be stored in `UserDefaults`, `NSUbiquitousKeyValueStore` or a custom key-value store depending on how they are configured.
 
 Once your settings are set up, you can quickly add a settings view to your app using ``DCSettingsView``. This view displays a list of all the setting groups and settings that you’ve configured using the given ``DCSettingsManager``. You can create an instance of this view and add it to your app’s view hierarchy like any other SwiftUI view.
 
 > Note: The settings configuration and storage APIs support the package's minimum platform versions, except ``DCSettingStore/ubiquitous`` requires watchOS 9 or newer. ``DCSettingsView`` is available on iOS 14, macOS 11, tvOS 14, watchOS 7, and visionOS 2 or newer.
 
-DCSettings stores property-list compatible values (`Bool`, `Int`, `Double`, `String`, `Date`, and `Data`) directly in the selected backing store. Other values must conform to `Codable`; they are JSON-encoded to `Data` before storage and decoded when read back. Custom ``DCKeyValueStore`` implementations should accept `Data` values to support custom `Codable` setting types.
+> Note: ``DCSettingsManager``, ``DCSetting``, the stored-value property wrappers, and the SwiftUI settings views are main-actor isolated. The lower-level ``DCSettingStore`` and ``DCKeyValueStore`` storage APIs remain actor-neutral.
+
+DCSettings stores property-list compatible values (`Bool`, `Int`, `Double`, `String`, `Date`, and `Data`) directly in the selected backing store. Other values must conform to `Codable`; they are JSON-encoded to `Data` before storage and decoded when read back. Values that are neither property-list compatible nor `Codable` are rejected in debug builds with an assertion and are not persisted. Custom ``DCKeyValueStore`` implementations should accept `Data` values to support custom `Codable` setting types.
 
 *Example configuration:*
 

--- a/Sources/DCSettings/Documentation.docc/DCSettings.md
+++ b/Sources/DCSettings/Documentation.docc/DCSettings.md
@@ -10,6 +10,8 @@ Once your settings are set up, you can quickly add a settings view to your app u
 
 > Note: The settings configuration and storage APIs support the package's minimum platform versions, except ``DCSettingStore/ubiquitous`` requires watchOS 9 or newer. ``DCSettingsView`` is available on iOS 14, macOS 11, tvOS 14, watchOS 7, and visionOS 2 or newer.
 
+DCSettings stores property-list compatible values (`Bool`, `Int`, `Double`, `String`, `Date`, and `Data`) directly in the selected backing store. Other values must conform to `Codable`; they are JSON-encoded to `Data` before storage and decoded when read back. Custom ``DCKeyValueStore`` implementations should accept `Data` values to support custom `Codable` setting types.
+
 *Example configuration:*
 
 ```swift
@@ -36,7 +38,13 @@ DCSettingsManager.shared.configure {
             DCSettingOption(value: "Light", label: "Light")
             DCSettingOption(value: "Dark", label: "Dark")
         }
-        DCSetting(key: "fontSize", options: [12, 14, 16, 18, 20], defaultIndex: 2)
+        DCSetting(key: "fontSize", label: "Font Size") {
+            DCSettingOption(value: 12, label: "12 pt")
+            DCSettingOption(value: 14, label: "14 pt")
+            DCSettingOption(value: 16, label: "16 pt").default()
+            DCSettingOption(value: 18, label: "18 pt")
+            DCSettingOption(value: 20, label: "20 pt")
+        }
         DCSetting(key: "lineSpacing", defaultValue: 1.2, lowerBound: 1.0, upperBound: 1.6, step: 0.1)
         DCSetting(key: "highlightColor", defaultValue: Color.blue)
     }

--- a/Sources/DCSettings/Extensions/Collection+Extended.swift
+++ b/Sources/DCSettings/Extensions/Collection+Extended.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 extension Collection {
-    
+
     func get(_ index: Index) -> Element? {
         if indices.contains(index) {
             return self[index]

--- a/Sources/DCSettings/Extensions/Color+Codable.swift
+++ b/Sources/DCSettings/Extensions/Color+Codable.swift
@@ -14,14 +14,11 @@ import AppKit
 #endif
 
 #if compiler(>=6.0)
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
 extension Color: @retroactive Codable {}
 #else
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
 extension Color: Codable {}
 #endif
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
 extension Color {
     
     #if canImport(UIKit)

--- a/Sources/DCSettings/Extensions/Color+Codable.swift
+++ b/Sources/DCSettings/Extensions/Color+Codable.swift
@@ -13,12 +13,6 @@ import UIKit
 import AppKit
 #endif
 
-#if compiler(>=6.0)
-extension Color: @retroactive Codable {}
-#else
-extension Color: Codable {}
-#endif
-
 extension Color {
 
     #if canImport(UIKit)
@@ -27,6 +21,30 @@ extension Color {
     typealias NativeColor = NSColor
     #endif
 
+    func dcSettingsEncodedData() throws -> Data {
+        let nativeColor = NativeColor(self)
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        nativeColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+        let components = DCColorComponents(red: red, green: green, blue: blue, opacity: alpha)
+        return try JSONEncoder().encode(components)
+    }
+
+    init(dcSettingsData data: Data) throws {
+        let components = try JSONDecoder().decode(DCColorComponents.self, from: data)
+        self.init(NativeColor(red: components.red, green: components.green, blue: components.blue, alpha: components.opacity))
+    }
+}
+
+private struct DCColorComponents: Codable {
+    let red: CGFloat
+    let green: CGFloat
+    let blue: CGFloat
+    let opacity: CGFloat
+
     private enum CodingKeys: String, CodingKey {
         case red
         case green
@@ -34,29 +52,26 @@ extension Color {
         case opacity
     }
 
-    public func encode(to encoder: Encoder) throws {
+    init(red: CGFloat, green: CGFloat, blue: CGFloat, opacity: CGFloat) {
+        self.red = red
+        self.green = green
+        self.blue = blue
+        self.opacity = opacity
+    }
+
+    func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        let nativeColor = NativeColor(self)
-
-        var red: CGFloat = 0
-        var green: CGFloat = 0
-        var blue: CGFloat = 0
-        var alpha: CGFloat = 0
-        nativeColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
-
         try container.encode(red, forKey: .red)
         try container.encode(green, forKey: .green)
         try container.encode(blue, forKey: .blue)
-        try container.encode(alpha, forKey: .opacity)
+        try container.encode(opacity, forKey: .opacity)
     }
 
-    public init(from decoder: Decoder) throws {
+    init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let red = try container.decode(CGFloat.self, forKey: .red)
-        let green = try container.decode(CGFloat.self, forKey: .green)
-        let blue = try container.decode(CGFloat.self, forKey: .blue)
-        let opacity = try container.decode(CGFloat.self, forKey: .opacity)
-
-        self.init(NativeColor(red: red, green: green, blue: blue, alpha: opacity))
+        red = try container.decode(CGFloat.self, forKey: .red)
+        green = try container.decode(CGFloat.self, forKey: .green)
+        blue = try container.decode(CGFloat.self, forKey: .blue)
+        opacity = try container.decode(CGFloat.self, forKey: .opacity)
     }
 }

--- a/Sources/DCSettings/Extensions/Color+Codable.swift
+++ b/Sources/DCSettings/Extensions/Color+Codable.swift
@@ -13,8 +13,16 @@ import UIKit
 import AppKit
 #endif
 
+#if compiler(>=6.0)
 @available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
-extension Color: Codable {
+extension Color: @retroactive Codable {}
+#else
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+extension Color: Codable {}
+#endif
+
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+extension Color {
     
     #if canImport(UIKit)
     typealias NativeColor = UIColor

--- a/Sources/DCSettings/Extensions/Color+Codable.swift
+++ b/Sources/DCSettings/Extensions/Color+Codable.swift
@@ -20,13 +20,13 @@ extension Color: Codable {}
 #endif
 
 extension Color {
-    
+
     #if canImport(UIKit)
     typealias NativeColor = UIColor
     #elseif canImport(AppKit)
     typealias NativeColor = NSColor
     #endif
-    
+
     private enum CodingKeys: String, CodingKey {
         case red
         case green
@@ -37,13 +37,13 @@ extension Color {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         let nativeColor = NativeColor(self)
-        
+
         var red: CGFloat = 0
         var green: CGFloat = 0
         var blue: CGFloat = 0
         var alpha: CGFloat = 0
         nativeColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
-        
+
         try container.encode(red, forKey: .red)
         try container.encode(green, forKey: .green)
         try container.encode(blue, forKey: .blue)
@@ -56,7 +56,7 @@ extension Color {
         let green = try container.decode(CGFloat.self, forKey: .green)
         let blue = try container.decode(CGFloat.self, forKey: .blue)
         let opacity = try container.decode(CGFloat.self, forKey: .opacity)
-        
+
         self.init(NativeColor(red: red, green: green, blue: blue, alpha: opacity))
     }
 }

--- a/Sources/DCSettings/Extensions/DCKeyRepresentableConformances.swift
+++ b/Sources/DCSettings/Extensions/DCKeyRepresentableConformances.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 extension String: DCKeyRepresentable {
-    
+
     /// The key value of the string.
     ///
     /// This property returns the string itself.
@@ -17,7 +17,7 @@ extension String: DCKeyRepresentable {
 }
 
 extension UUID: DCKeyRepresentable {
-    
+
     /// The key value of the `UUID`.
     ///
     /// This property returns the string representation of the `UUID`.

--- a/Sources/DCSettings/Extensions/NSUbiquitousKeyValueStore+DCKeyValueStore.swift
+++ b/Sources/DCSettings/Extensions/NSUbiquitousKeyValueStore+DCKeyValueStore.swift
@@ -9,7 +9,7 @@ import Combine
 
 @available(watchOS 9.0, *)
 extension NSUbiquitousKeyValueStore: DCKeyValueStore {
-    
+
     /// Sets the value of the specified key in the key-value store.
     ///
     /// - Parameters:
@@ -18,7 +18,7 @@ extension NSUbiquitousKeyValueStore: DCKeyValueStore {
     public func set(_ value: Int, forKey key: String) {
         setValue(Int64(value), forKey: key)
     }
-    
+
     /// Returns the integer value associated with the specified key.
     ///
     /// - Parameter key: A key in the current key-value store.
@@ -27,7 +27,7 @@ extension NSUbiquitousKeyValueStore: DCKeyValueStore {
     public func integer(forKey key: String) -> Int {
         return Int(exactly: longLong(forKey: key)) ?? 0
     }
-    
+
     /// Returns a publisher that emits the value associated with the specified key whenever it changes.
     ///
     /// - Parameter key: The key for the value to observe.
@@ -39,7 +39,7 @@ extension NSUbiquitousKeyValueStore: DCKeyValueStore {
                 guard let changedKeys = notification.userInfo?[NSUbiquitousKeyValueStoreChangedKeysKey] as? [String] else {
                     return true
                 }
-                
+
                 return changedKeys.contains(key)
             }
             .map { _ in self.object(forKey: key) }

--- a/Sources/DCSettings/Extensions/NSUbiquitousKeyValueStore+DCKeyValueStore.swift
+++ b/Sources/DCSettings/Extensions/NSUbiquitousKeyValueStore+DCKeyValueStore.swift
@@ -35,6 +35,13 @@ extension NSUbiquitousKeyValueStore: DCKeyValueStore {
     /// - Returns: A publisher that emits the value associated with the specified key whenever it changes.
     public func valuePublisher(forKey key: String) -> AnyPublisher<Any?, Never> {
         let notificationPublisher = NotificationCenter.default.publisher(for: NSUbiquitousKeyValueStore.didChangeExternallyNotification, object: self)
+            .filter { notification in
+                guard let changedKeys = notification.userInfo?[NSUbiquitousKeyValueStoreChangedKeysKey] as? [String] else {
+                    return true
+                }
+                
+                return changedKeys.contains(key)
+            }
             .map { _ in self.object(forKey: key) }
         let initialValuePublisher = Just(self.object(forKey: key))
         return initialValuePublisher.merge(with: notificationPublisher).eraseToAnyPublisher()

--- a/Sources/DCSettings/Extensions/String+Extended.swift
+++ b/Sources/DCSettings/Extensions/String+Extended.swift
@@ -15,6 +15,31 @@ extension String {
     }
     
     var sentenceFormatted: String {
-        self.replacingOccurrences(of: "_", with: " ").replacingOccurrences(of: "([A-Z0-9]+)", with: " $1", options: .regularExpression, range: range(of: self)).trimmingCharacters(in: .whitespacesAndNewlines).sentenceCapitalized
+        let separatedWords = self
+            .replacingOccurrences(of: "_", with: " ")
+            .replacingOccurrences(of: "([A-Z]+)([A-Z][a-z])", with: "$1 $2", options: .regularExpression)
+            .replacingOccurrences(of: "([a-z0-9])([A-Z])", with: "$1 $2", options: .regularExpression)
+            .replacingOccurrences(of: "([A-Za-z])([0-9])", with: "$1 $2", options: .regularExpression)
+            .replacingOccurrences(of: "([0-9])([A-Za-z])", with: "$1 $2", options: .regularExpression)
+        
+        return separatedWords
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .enumerated()
+            .map { index, word in
+                if word.isUppercaseAcronym {
+                    return word
+                }
+                
+                return index == 0 ? word.sentenceCapitalized : word.lowercased()
+            }
+            .joined(separator: " ")
+    }
+}
+
+private extension String {
+    
+    var isUppercaseAcronym: Bool {
+        range(of: #"^[A-Z0-9]+$"#, options: .regularExpression) != nil
     }
 }

--- a/Sources/DCSettings/Extensions/String+Extended.swift
+++ b/Sources/DCSettings/Extensions/String+Extended.swift
@@ -7,13 +7,13 @@
 import Foundation
 
 extension String {
-    
+
     var sentenceCapitalized: String {
         let firstLetter = self.prefix(1).capitalized
         let remainingLetters = self.dropFirst().lowercased()
         return firstLetter + remainingLetters
     }
-    
+
     var sentenceFormatted: String {
         let separatedWords = self
             .replacingOccurrences(of: "_", with: " ")
@@ -21,7 +21,7 @@ extension String {
             .replacingOccurrences(of: "([a-z0-9])([A-Z])", with: "$1 $2", options: .regularExpression)
             .replacingOccurrences(of: "([A-Za-z])([0-9])", with: "$1 $2", options: .regularExpression)
             .replacingOccurrences(of: "([0-9])([A-Za-z])", with: "$1 $2", options: .regularExpression)
-        
+
         return separatedWords
             .components(separatedBy: .whitespacesAndNewlines)
             .filter { !$0.isEmpty }
@@ -30,7 +30,7 @@ extension String {
                 if word.isUppercaseAcronym {
                     return word
                 }
-                
+
                 return index == 0 ? word.sentenceCapitalized : word.lowercased()
             }
             .joined(separator: " ")
@@ -38,7 +38,7 @@ extension String {
 }
 
 private extension String {
-    
+
     var isUppercaseAcronym: Bool {
         range(of: #"^[A-Z0-9]+$"#, options: .regularExpression) != nil
     }

--- a/Sources/DCSettings/Extensions/Text+MonospacedDigit.swift
+++ b/Sources/DCSettings/Extensions/Text+MonospacedDigit.swift
@@ -7,7 +7,7 @@
 import SwiftUI
 
 extension Text {
-    
+
     public func monospacedDigitIfAvailable() -> Text {
         if #available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 9.0, visionOS 1.0, *) {
             return self.monospacedDigit()

--- a/Sources/DCSettings/Extensions/UserDefaults+DCKeyValueStore.swift
+++ b/Sources/DCSettings/Extensions/UserDefaults+DCKeyValueStore.swift
@@ -21,14 +21,14 @@ private func areKeyValueStoreObjectsEqual(_ lhs: Any?, _ rhs: Any?) -> Bool {
 }
 
 extension UserDefaults: DCKeyValueStore {
-    
+
     /// Returns a publisher that emits the value associated with the specified key whenever it changes.
     ///
     /// - Parameter key: The key for the value to observe.
     ///
     /// - Returns: A publisher that emits the value associated with the specified key whenever it changes.
     public func valuePublisher(forKey key: String) -> AnyPublisher<Any?, Never> {
-        let notificationPublisher = NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification, object: self)
+        let notificationPublisher = NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)
             .map { _ in self.object(forKey: key) }
         let initialValuePublisher = Just(self.object(forKey: key))
         return initialValuePublisher.merge(with: notificationPublisher)

--- a/Sources/DCSettings/Extensions/UserDefaults+DCKeyValueStore.swift
+++ b/Sources/DCSettings/Extensions/UserDefaults+DCKeyValueStore.swift
@@ -7,6 +7,19 @@
 import Foundation
 import Combine
 
+private func areKeyValueStoreObjectsEqual(_ lhs: Any?, _ rhs: Any?) -> Bool {
+    switch (lhs, rhs) {
+    case (nil, nil):
+        return true
+    case (nil, _), (_, nil):
+        return false
+    case let (lhs as NSObject, rhs as NSObject):
+        return lhs.isEqual(rhs)
+    default:
+        return false
+    }
+}
+
 extension UserDefaults: DCKeyValueStore {
     
     /// Returns a publisher that emits the value associated with the specified key whenever it changes.
@@ -18,6 +31,8 @@ extension UserDefaults: DCKeyValueStore {
         let notificationPublisher = NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification, object: self)
             .map { _ in self.object(forKey: key) }
         let initialValuePublisher = Just(self.object(forKey: key))
-        return initialValuePublisher.merge(with: notificationPublisher).eraseToAnyPublisher()
+        return initialValuePublisher.merge(with: notificationPublisher)
+            .removeDuplicates(by: areKeyValueStoreObjectsEqual)
+            .eraseToAnyPublisher()
     }
 }

--- a/Sources/DCSettings/Extensions/UserDefaults+DCKeyValueStore.swift
+++ b/Sources/DCSettings/Extensions/UserDefaults+DCKeyValueStore.swift
@@ -28,7 +28,7 @@ extension UserDefaults: DCKeyValueStore {
     ///
     /// - Returns: A publisher that emits the value associated with the specified key whenever it changes.
     public func valuePublisher(forKey key: String) -> AnyPublisher<Any?, Never> {
-        let notificationPublisher = NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)
+        let notificationPublisher = NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification, object: self)
             .map { _ in self.object(forKey: key) }
         let initialValuePublisher = Just(self.object(forKey: key))
         return initialValuePublisher.merge(with: notificationPublisher)

--- a/Sources/DCSettings/Settings/DCKeyRepresentable.swift
+++ b/Sources/DCSettings/Settings/DCKeyRepresentable.swift
@@ -10,7 +10,7 @@ import Foundation
 ///
 /// Conforming types must implement the `keyValue` property to provide a string representation of the instance.
 public protocol DCKeyRepresentable {
-    
+
     /// A string representation of the instance.
     var keyValue: String { get }
 }

--- a/Sources/DCSettings/Settings/DCSetting.swift
+++ b/Sources/DCSettings/Settings/DCSetting.swift
@@ -180,7 +180,7 @@ public class DCSetting<ValueType>: DCSettable where ValueType: Equatable {
     ///   - key: The key used to identify the setting in the store.
     ///   - label: An optional label for the setting. The default value is `nil`.
     ///   - store: An optional `DCSettingStore` instance used to store the setting value. The default value is `nil`.
-    ///   - options: An array of `DCSettingOption` instances.
+    ///   - configuredOptions: An array of `DCSettingOption` instances.
     public convenience init?(key: DCKeyRepresentable, label: String? = nil, store: DCSettingStore? = nil, options configuredOptions: [DCSettingOption<ValueType>]) {
         if let defaultValue = configuredOptions.first(where: { $0.isDefault })?.value ?? configuredOptions.first?.value {
             self.init(key: key, value: defaultValue, label: label, configuation: DCSettingConfiguration<ValueType>(options: configuredOptions, bounds: nil, step: nil), store: store)
@@ -251,11 +251,11 @@ public class DCSetting<ValueType>: DCSettable where ValueType: Equatable {
     
     private func setUpListener() {
         guard let store = store else { return }
-        cancellable = store.valuePublisher(forKey: key)
+        cancellable = store.valuePublisher(forKey: key, as: ValueType.self)
             .receive(on: RunLoop.main)
             .sink { [weak self] newValue in
-                if let newTypedValue = newValue as? ValueType, self?.value != newTypedValue {
-                    self?.value = newTypedValue
+                if let newValue = newValue, self?.value != newValue {
+                    self?.value = newValue
                 }
             }
     }

--- a/Sources/DCSettings/Settings/DCSetting.swift
+++ b/Sources/DCSettings/Settings/DCSetting.swift
@@ -31,6 +31,10 @@ public protocol DCSettable<ValueType>: ObservableObject where ValueType: Equatab
     var value: ValueType { get set }
     
     /// An optional configuration for the setting.
+    var configuration: DCSettingConfiguration<ValueType>? { get }
+    
+    /// An optional configuration for the setting.
+    @available(*, deprecated, renamed: "configuration")
     var configuation: DCSettingConfiguration<ValueType>? { get }
     
     /// An optional `DCSettingStore` instance used to store the setting value.
@@ -82,16 +86,22 @@ public class DCSetting<ValueType>: DCSettable where ValueType: Equatable {
     public var store: DCSettingStore?
     
     /// An optional configuration for the setting.
-    public let configuation: DCSettingConfiguration<ValueType>?
+    public let configuration: DCSettingConfiguration<ValueType>?
+    
+    /// An optional configuration for the setting.
+    @available(*, deprecated, renamed: "configuration")
+    public var configuation: DCSettingConfiguration<ValueType>? {
+        configuration
+    }
     
     private var cancellable: AnyCancellable?
     
-    private init(key: DCKeyRepresentable, value: ValueType, label: String?, configuation: DCSettingConfiguration<ValueType>?, store: DCSettingStore?) {
+    private init(key: DCKeyRepresentable, value: ValueType, label: String?, configuration: DCSettingConfiguration<ValueType>?, store: DCSettingStore?) {
         self.key = key.keyValue
         self._value = value
         self.label = label
         self.store = store
-        self.configuation = configuation
+        self.configuration = configuration
     }
     
     /// Initializes a new `DCSetting` instance with the specified key, default value, label, and store.
@@ -104,7 +114,7 @@ public class DCSetting<ValueType>: DCSettable where ValueType: Equatable {
     ///   - label: An optional label for the setting. The default value is `nil`.
     ///   - store: An optional `DCSettingStore` instance used to store the setting value. The default value is `nil`.
     public convenience init(key: DCKeyRepresentable, defaultValue: ValueType, label: String? = nil, store: DCSettingStore? = nil) {
-        self.init(key: key.keyValue, value: defaultValue, label: label, configuation: nil, store: store)
+        self.init(key: key.keyValue, value: defaultValue, label: label, configuration: nil, store: store)
     }
 
     /// Initializes a new `DCSetting` instance with the specified key, label, store, options array, and default index.
@@ -122,7 +132,7 @@ public class DCSetting<ValueType>: DCSettable where ValueType: Equatable {
     public convenience init?(key: DCKeyRepresentable, label: String? = nil, store: DCSettingStore? = nil, options: [ValueType], defaultIndex: Int) where ValueType: LosslessStringConvertible {
         if let defaultValue = options.get(defaultIndex) {
             let configuredOptions = options.map { DCSettingOption(value: $0, label: String($0)) }
-            self.init(key: key, value: defaultValue, label: label, configuation: DCSettingConfiguration<ValueType>(options: configuredOptions, bounds: nil, step: nil), store: store)
+            self.init(key: key, value: defaultValue, label: label, configuration: DCSettingConfiguration<ValueType>(options: configuredOptions, bounds: nil, step: nil), store: store)
         }
         else {
             return nil
@@ -142,7 +152,7 @@ public class DCSetting<ValueType>: DCSettable where ValueType: Equatable {
     ///   - upperBound: The upper bound of the range of valid values for the setting.
     ///   - step: An optional step value that specifies the increment or decrement between valid values. The default value is `nil`.
     public convenience init(key: DCKeyRepresentable, defaultValue: ValueType, label: String? = nil, store: DCSettingStore? = nil, lowerBound: ValueType, upperBound: ValueType, step: ValueType? = nil) where ValueType: Numeric {
-        self.init(key: key, value: defaultValue, label: label, configuation: DCSettingConfiguration<ValueType>(options: nil, bounds: DCValueBounds(lowerBound: lowerBound, upperBound: upperBound), step: step), store: store)
+        self.init(key: key, value: defaultValue, label: label, configuration: DCSettingConfiguration<ValueType>(options: nil, bounds: DCValueBounds(lowerBound: lowerBound, upperBound: upperBound), step: step), store: store)
     }
     
     /// Initializes a new `DCSetting` instance with the specified key, label, store and result builder closure.
@@ -183,7 +193,7 @@ public class DCSetting<ValueType>: DCSettable where ValueType: Equatable {
     ///   - options: An array of `DCSettingOption` instances.
     public convenience init?(key: DCKeyRepresentable, label: String? = nil, store: DCSettingStore? = nil, options configuredOptions: [DCSettingOption<ValueType>]) {
         if let defaultValue = configuredOptions.first(where: { $0.isDefault })?.value ?? configuredOptions.first?.value {
-            self.init(key: key, value: defaultValue, label: label, configuation: DCSettingConfiguration<ValueType>(options: configuredOptions, bounds: nil, step: nil), store: store)
+            self.init(key: key, value: defaultValue, label: label, configuration: DCSettingConfiguration<ValueType>(options: configuredOptions, bounds: nil, step: nil), store: store)
         }
         else {
             return nil
@@ -225,6 +235,7 @@ public class DCSetting<ValueType>: DCSettable where ValueType: Equatable {
     public func refresh() {
         if let newValue: ValueType = store?.object(forKey: key), value != newValue {
             _value = newValue
+            objectWillChange.send()
         }
         setUpListener()
     }

--- a/Sources/DCSettings/Settings/DCSetting.swift
+++ b/Sources/DCSettings/Settings/DCSetting.swift
@@ -77,9 +77,10 @@ public extension DCSettable {
         }
         set {
             if _value != newValue {
-                _value = newValue
-                objectWillChange.send()
-                save()
+                if save(newValue) {
+                    _value = newValue
+                    objectWillChange.send()
+                }
             }
         }
     }
@@ -244,10 +245,11 @@ public extension DCSettable {
         setUpListener()
     }
 
-    private func save() {
+    private func save(_ value: ValueType) -> Bool {
         cancellable = nil
-        store?.set(value, forKey: key)
+        let didSave = store?.set(value, forKey: key) ?? true
         setUpListener()
+        return didSave
     }
 
     /// Returns a binding for the current value of the setting.

--- a/Sources/DCSettings/Settings/DCSetting.swift
+++ b/Sources/DCSettings/Settings/DCSetting.swift
@@ -16,7 +16,7 @@ import SwiftUI
 /// It also includes a property for the `DCSettingStore` instance used to store the setting value.
 ///
 /// The protocol also includes a `refresh` method that can be used to refresh the setting value from the store.
-public protocol DCSettable<ValueType>: ObservableObject where ValueType: Equatable {
+@MainActor public protocol DCSettable<ValueType>: ObservableObject where ValueType: Equatable {
 
     /// The type of value associated with the setting.
     associatedtype ValueType
@@ -60,7 +60,7 @@ public extension DCSettable {
 /// The class also includes several convenience initializers that can be used to create new instances of `DCSetting` with different configurations.
 ///
 /// - Note: If the store is not set when the setting is configured by a manager instance, the store of the group in which the setting resides will be used.
-public class DCSetting<ValueType>: DCSettable where ValueType: Equatable {
+@MainActor public class DCSetting<ValueType>: DCSettable where ValueType: Equatable {
 
     /// The key used to identify the setting in the store.
     public let key: String
@@ -175,7 +175,7 @@ public class DCSetting<ValueType>: DCSettable where ValueType: Equatable {
     ///   - label: An optional label for the setting. The default value is `nil`.
     ///   - store: An optional `DCSettingStore` instance used to store the setting value. The default value is `nil`.
     ///   - builder: A result builder closure that constructs an array of `DCSettingOption` instances.
-    public convenience init?(key: DCKeyRepresentable, label: String? = nil, store: DCSettingStore? = nil, @DCSettingOptionsBuilder _ builder: () -> [DCSettingOption<ValueType>]) {
+    public convenience init?(key: DCKeyRepresentable, label: String? = nil, store: DCSettingStore? = nil, @DCSettingOptionsBuilder _ builder: @MainActor () -> [DCSettingOption<ValueType>]) {
         self.init(key: key, label: label, store: store, options: builder())
     }
 
@@ -290,7 +290,7 @@ public class DCSetting<ValueType>: DCSettable where ValueType: Equatable {
 /// }
 /// ```
 @resultBuilder
-public struct DCSettingsBuilder {
+@MainActor public struct DCSettingsBuilder {
 
     /// Constructs an array of `DCSettable` instances from the provided expressions.
     ///

--- a/Sources/DCSettings/Settings/DCSetting.swift
+++ b/Sources/DCSettings/Settings/DCSetting.swift
@@ -17,31 +17,35 @@ import SwiftUI
 ///
 /// The protocol also includes a `refresh` method that can be used to refresh the setting value from the store.
 public protocol DCSettable<ValueType>: ObservableObject where ValueType: Equatable {
-    
+
     /// The type of value associated with the setting.
     associatedtype ValueType
-    
+
     /// An optional label for the setting.
     var label: String? { get }
-    
+
     /// The key used to identify the setting in the store.
     var key: String { get }
-    
+
     /// The current value of the setting.
     var value: ValueType { get set }
-    
+
     /// An optional configuration for the setting.
-    var configuration: DCSettingConfiguration<ValueType>? { get }
-    
-    /// An optional configuration for the setting.
-    @available(*, deprecated, renamed: "configuration")
     var configuation: DCSettingConfiguration<ValueType>? { get }
-    
+
     /// An optional `DCSettingStore` instance used to store the setting value.
     var store: DCSettingStore? { get set }
-    
+
     /// Refreshes the setting value from the store.
     func refresh()
+}
+
+public extension DCSettable {
+
+    /// An optional configuration for the setting.
+    var configuration: DCSettingConfiguration<ValueType>? {
+        configuation
+    }
 }
 
 /// A class that represents a settable value with a specific type.
@@ -57,15 +61,15 @@ public protocol DCSettable<ValueType>: ObservableObject where ValueType: Equatab
 ///
 /// - Note: If the store is not set when the setting is configured by a manager instance, the store of the group in which the setting resides will be used.
 public class DCSetting<ValueType>: DCSettable where ValueType: Equatable {
-    
+
     /// The key used to identify the setting in the store.
     public let key: String
-    
+
     /// An optional label for the setting.
     public let label: String?
-    
+
     private var _value: ValueType
-    
+
     /// The current value of the setting.
     public var value: ValueType {
         get {
@@ -79,23 +83,23 @@ public class DCSetting<ValueType>: DCSettable where ValueType: Equatable {
             }
         }
     }
-    
+
     /// An optional `DCSettingStore` instance used to store the setting value.
     ///
     /// If not provided when initialized, this will be set to the store of the group in which the setting resides when configured by a manager.
     public var store: DCSettingStore?
-    
+
     /// An optional configuration for the setting.
     public let configuration: DCSettingConfiguration<ValueType>?
-    
+
     /// An optional configuration for the setting.
     @available(*, deprecated, renamed: "configuration")
     public var configuation: DCSettingConfiguration<ValueType>? {
         configuration
     }
-    
+
     private var cancellable: AnyCancellable?
-    
+
     private init(key: DCKeyRepresentable, value: ValueType, label: String?, configuration: DCSettingConfiguration<ValueType>?, store: DCSettingStore?) {
         self.key = key.keyValue
         self._value = value
@@ -103,7 +107,7 @@ public class DCSetting<ValueType>: DCSettable where ValueType: Equatable {
         self.store = store
         self.configuration = configuration
     }
-    
+
     /// Initializes a new `DCSetting` instance with the specified key, default value, label, and store.
     ///
     /// If a store is not provided, the store of the group in which the setting resides will be used once configured.
@@ -154,7 +158,7 @@ public class DCSetting<ValueType>: DCSettable where ValueType: Equatable {
     public convenience init(key: DCKeyRepresentable, defaultValue: ValueType, label: String? = nil, store: DCSettingStore? = nil, lowerBound: ValueType, upperBound: ValueType, step: ValueType? = nil) where ValueType: Numeric {
         self.init(key: key, value: defaultValue, label: label, configuration: DCSettingConfiguration<ValueType>(options: nil, bounds: DCValueBounds(lowerBound: lowerBound, upperBound: upperBound), step: step), store: store)
     }
-    
+
     /// Initializes a new `DCSetting` instance with the specified key, label, store and result builder closure.
     ///
     /// This convenience initializer creates a new instance of `DCSetting` with an array of options constructed using a result builder closure.
@@ -174,7 +178,7 @@ public class DCSetting<ValueType>: DCSettable where ValueType: Equatable {
     public convenience init?(key: DCKeyRepresentable, label: String? = nil, store: DCSettingStore? = nil, @DCSettingOptionsBuilder _ builder: () -> [DCSettingOption<ValueType>]) {
         self.init(key: key, label: label, store: store, options: builder())
     }
-    
+
     /// Initializes a new `DCSetting` instance with the specified key, label, store and options.
     ///
     /// This convenience initializer creates a new instance of `DCSetting` with an array of options.
@@ -199,7 +203,7 @@ public class DCSetting<ValueType>: DCSettable where ValueType: Equatable {
             return nil
         }
     }
-    
+
     /// Initializes a new `DCSetting` instance with the specified key and options provider.
     ///
     /// - Parameters:
@@ -224,7 +228,7 @@ public class DCSetting<ValueType>: DCSettable where ValueType: Equatable {
             return nil
         }
     }
-    
+
     /// Refreshes the setting value from the store.
     ///
     /// This method refreshes the current value of the setting from the store.
@@ -239,13 +243,13 @@ public class DCSetting<ValueType>: DCSettable where ValueType: Equatable {
         }
         setUpListener()
     }
-    
+
     private func save() {
         cancellable = nil
         store?.set(value, forKey: key)
         setUpListener()
     }
-    
+
     /// Returns a binding for the current value of the setting.
     ///
     /// This method returns a `Binding` instance for the current value of the setting.
@@ -259,7 +263,7 @@ public class DCSetting<ValueType>: DCSettable where ValueType: Equatable {
             self.value = newValue
         }
     }
-    
+
     private func setUpListener() {
         guard let store = store else { return }
         cancellable = store.valuePublisher(forKey: key, as: ValueType.self)
@@ -287,7 +291,7 @@ public class DCSetting<ValueType>: DCSettable where ValueType: Equatable {
 /// ```
 @resultBuilder
 public struct DCSettingsBuilder {
-    
+
     /// Constructs an array of `DCSettable` instances from the provided expressions.
     ///
     /// This method is called by the result builder to construct the final result from the provided expressions.

--- a/Sources/DCSettings/Settings/DCSetting.swift
+++ b/Sources/DCSettings/Settings/DCSetting.swift
@@ -31,7 +31,7 @@ import SwiftUI
     var value: ValueType { get set }
 
     /// An optional configuration for the setting.
-    var configuation: DCSettingConfiguration<ValueType>? { get }
+    var configuration: DCSettingConfiguration<ValueType>? { get }
 
     /// An optional `DCSettingStore` instance used to store the setting value.
     var store: DCSettingStore? { get set }
@@ -43,8 +43,9 @@ import SwiftUI
 public extension DCSettable {
 
     /// An optional configuration for the setting.
-    var configuration: DCSettingConfiguration<ValueType>? {
-        configuation
+    @available(*, deprecated, renamed: "configuration")
+    var configuation: DCSettingConfiguration<ValueType>? {
+        configuration
     }
 }
 
@@ -166,7 +167,7 @@ public extension DCSettable {
     ///
     /// If no options are provided in the result builder closure, this initializer will return `nil`.
     ///
-    /// If no default option in the result builder has be set as the default, the first option will be used as default.
+    /// If no default option in the result builder has been set as the default, the first option will be used as default.
     /// If multiple options are set as default in the result builder, the first default option will be used as default.
     ///
     /// If a store is not provided, the store of the group in which the setting resides will be used once configured.
@@ -186,7 +187,7 @@ public extension DCSettable {
     ///
     /// If the option array is empty, this initializer will return `nil`.
     ///
-    /// If no default option in the array has be set as the default, the first option will be used as default.
+    /// If no default option in the array has been set as the default, the first option will be used as default.
     /// If multiple options are set as default in the array, the first default option will be used as default.
     ///
     /// If a store is not provided, the store of the group in which the setting resides will be used once configured.
@@ -235,7 +236,7 @@ public extension DCSettable {
     /// This method refreshes the current value of the setting from the store.
     /// If a new value is found in the store and is different from the current value, the current value will be updated.
     ///
-    /// This is called during the initial configuatrion of the setting by the managing `DCSettingsManager` instance.
+    /// This is called during the initial configuration of the setting by the managing `DCSettingsManager` instance.
     /// Calling this directly on a setting should be avoided.
     public func refresh() {
         if let newValue: ValueType = store?.object(forKey: key), value != newValue {
@@ -271,9 +272,12 @@ public extension DCSettable {
         cancellable = store.valuePublisher(forKey: key, as: ValueType.self)
             .receive(on: RunLoop.main)
             .sink { [weak self] newValue in
-                if let newValue = newValue, self?.value != newValue {
-                    self?.value = newValue
+                guard let self, let newValue, self._value != newValue else {
+                    return
                 }
+
+                self._value = newValue
+                self.objectWillChange.send()
             }
     }
 }
@@ -301,7 +305,35 @@ public extension DCSettable {
     ///
     /// - Parameter settings: A variadic list of optional `DCSettable` instances.
     /// - Returns: An array of `DCSettable` instances.
+    public static func buildBlock() -> [any DCSettable] {
+        []
+    }
+
     public static func buildBlock(_ settings: (any DCSettable)?...) -> [any DCSettable] {
         settings.compactMap { $0 }
+    }
+
+    public static func buildExpression(_ setting: (any DCSettable)?) -> [any DCSettable] {
+        setting.map { [$0] } ?? []
+    }
+
+    public static func buildBlock(_ components: [any DCSettable]...) -> [any DCSettable] {
+        components.flatMap { $0 }
+    }
+
+    public static func buildOptional(_ component: [any DCSettable]?) -> [any DCSettable] {
+        component ?? []
+    }
+
+    public static func buildEither(first component: [any DCSettable]) -> [any DCSettable] {
+        component
+    }
+
+    public static func buildEither(second component: [any DCSettable]) -> [any DCSettable] {
+        component
+    }
+
+    public static func buildArray(_ components: [[any DCSettable]]) -> [any DCSettable] {
+        components.flatMap { $0 }
     }
 }

--- a/Sources/DCSettings/Settings/DCSetting.swift
+++ b/Sources/DCSettings/Settings/DCSetting.swift
@@ -180,7 +180,7 @@ public class DCSetting<ValueType>: DCSettable where ValueType: Equatable {
     ///   - key: The key used to identify the setting in the store.
     ///   - label: An optional label for the setting. The default value is `nil`.
     ///   - store: An optional `DCSettingStore` instance used to store the setting value. The default value is `nil`.
-    ///   - configuredOptions: An array of `DCSettingOption` instances.
+    ///   - options: An array of `DCSettingOption` instances.
     public convenience init?(key: DCKeyRepresentable, label: String? = nil, store: DCSettingStore? = nil, options configuredOptions: [DCSettingOption<ValueType>]) {
         if let defaultValue = configuredOptions.first(where: { $0.isDefault })?.value ?? configuredOptions.first?.value {
             self.init(key: key, value: defaultValue, label: label, configuation: DCSettingConfiguration<ValueType>(options: configuredOptions, bounds: nil, step: nil), store: store)

--- a/Sources/DCSettings/Settings/DCSettingConfiguration.swift
+++ b/Sources/DCSettings/Settings/DCSettingConfiguration.swift
@@ -16,13 +16,13 @@ import Foundation
 ///
 /// - Note: The value type must conform to the `Equatable` protocol.
 public struct DCSettingConfiguration<ValueType>: Equatable where ValueType: Equatable {
-    
+
     /// An optional array of `DCSettingOption` instances representing the available options for the setting.
     public let options: [DCSettingOption<ValueType>]?
-    
+
     /// An optional `DCValueBounds` instance representing the range of valid values for the setting.
     public let bounds: DCValueBounds<ValueType>?
-    
+
     /// An optional step value that specifies the increment or decrement between valid values.
     public let step: ValueType?
 }

--- a/Sources/DCSettings/Settings/DCSettingGroup.swift
+++ b/Sources/DCSettings/Settings/DCSettingGroup.swift
@@ -118,7 +118,35 @@ extension DCSettingGroup {
     ///
     /// - Parameter settings: The setting group instances to include in the array.
     /// - Returns: An array of setting groups.
+    public static func buildBlock() -> [DCSettingGroup] {
+        []
+    }
+
     public static func buildBlock(_ settings: DCSettingGroup...) -> [DCSettingGroup] {
         settings
+    }
+
+    public static func buildExpression(_ group: DCSettingGroup?) -> [DCSettingGroup] {
+        group.map { [$0] } ?? []
+    }
+
+    public static func buildBlock(_ components: [DCSettingGroup]...) -> [DCSettingGroup] {
+        components.flatMap { $0 }
+    }
+
+    public static func buildOptional(_ component: [DCSettingGroup]?) -> [DCSettingGroup] {
+        component ?? []
+    }
+
+    public static func buildEither(first component: [DCSettingGroup]) -> [DCSettingGroup] {
+        component
+    }
+
+    public static func buildEither(second component: [DCSettingGroup]) -> [DCSettingGroup] {
+        component
+    }
+
+    public static func buildArray(_ components: [[DCSettingGroup]]) -> [DCSettingGroup] {
+        components.flatMap { $0 }
     }
 }

--- a/Sources/DCSettings/Settings/DCSettingGroup.swift
+++ b/Sources/DCSettings/Settings/DCSettingGroup.swift
@@ -14,7 +14,7 @@ import Foundation
 /// You can create a `DCSettingGroup` using one of its initializers or by using the `@DCSettingsBuilder` result builder to build an array of settings.
 ///
 /// - Note: The `DCSettingGroup` conforms to the `Identifiable` protocol and uses its key as its `id`.
-public struct DCSettingGroup: Identifiable {
+@MainActor public struct DCSettingGroup: @MainActor Identifiable {
 
     /// The key for the setting group.
     public let key: String
@@ -66,7 +66,7 @@ public struct DCSettingGroup: Identifiable {
     ///   - label: The label for the setting group. Defaults to `nil`.
     ///   - store: The store for the setting group. Defaults to `.standard`.
     ///   - builder: A closure that builds an array of settings using the `@DCSettingsBuilder` result builder.
-    public init(key: DCKeyRepresentable?, label: String? = nil, store: DCSettingStore = .standard, @DCSettingsBuilder _ builder: () -> [any DCSettable]) {
+    public init(key: DCKeyRepresentable?, label: String? = nil, store: DCSettingStore = .standard, @DCSettingsBuilder _ builder: @MainActor () -> [any DCSettable]) {
         self.init(key: key, label: label, store: store, settings: builder())
     }
 
@@ -78,7 +78,7 @@ public struct DCSettingGroup: Identifiable {
     ///   - label: The label for the setting group. Defaults to `nil`.
     ///   - store: The store for the setting group. Defaults to `.standard`.
     ///   - builder: A closure that builds an array of settings using the `@DCSettingsBuilder` result builder.
-    public init(_ label: String? = nil, store: DCSettingStore = .standard, @DCSettingsBuilder _ builder: () -> [any DCSettable]) {
+    public init(_ label: String? = nil, store: DCSettingStore = .standard, @DCSettingsBuilder _ builder: @MainActor () -> [any DCSettable]) {
         self.init(key: nil, label: label, store: store, settings: builder())
     }
 }
@@ -112,7 +112,7 @@ extension DCSettingGroup {
 /// )
 /// ```
 @resultBuilder
-public struct DCSettingGroupsBuilder {
+@MainActor public struct DCSettingGroupsBuilder {
 
     /// Builds an array of setting groups from the provided setting group instances.
     ///

--- a/Sources/DCSettings/Settings/DCSettingGroup.swift
+++ b/Sources/DCSettings/Settings/DCSettingGroup.swift
@@ -15,24 +15,24 @@ import Foundation
 ///
 /// - Note: The `DCSettingGroup` conforms to the `Identifiable` protocol and uses its key as its `id`.
 public struct DCSettingGroup: Identifiable {
-    
+
     /// The key for the setting group.
     public let key: String
-    
+
     /// The label for the setting group.
     public let label: String?
-    
+
     /// The store for the setting group.
     public let store: DCSettingStore
-    
+
     /// The array of settings in the setting group.
     public let settings: [any DCSettable]
-    
+
     /// The identifier for the setting group.
     public var id: String {
         return key
     }
-    
+
     /// Creates a new setting group with the specified key, label, store, and settings.
     ///
     /// - Parameters:
@@ -46,7 +46,7 @@ public struct DCSettingGroup: Identifiable {
         self.store = store
         self.settings = settings
     }
-    
+
     /// Creates a new setting group with the specified label, store, and settings.
     ///
     /// A new `UUID` will be used as the group's key.
@@ -58,7 +58,7 @@ public struct DCSettingGroup: Identifiable {
     public init(_ label: String? = nil, store: DCSettingStore = .standard, settings: [any DCSettable]) {
         self.init(key: nil, label: label, store: store, settings: settings)
     }
-    
+
     /// Creates a new setting group with the specified key, label, store, and settings.
     ///
     /// - Parameters:
@@ -69,7 +69,7 @@ public struct DCSettingGroup: Identifiable {
     public init(key: DCKeyRepresentable?, label: String? = nil, store: DCSettingStore = .standard, @DCSettingsBuilder _ builder: () -> [any DCSettable]) {
         self.init(key: key, label: label, store: store, settings: builder())
     }
-    
+
     /// Creates a new setting group with the specified label, store, and settings.
     ///
     /// A new `UUID` will be used as the group's key.
@@ -84,7 +84,7 @@ public struct DCSettingGroup: Identifiable {
 }
 
 extension DCSettingGroup {
-    
+
     /// Returns a copy of the setting group with the specified store.
     ///
     /// - Parameter store: The new store for the setting group.
@@ -113,7 +113,7 @@ extension DCSettingGroup {
 /// ```
 @resultBuilder
 public struct DCSettingGroupsBuilder {
-    
+
     /// Builds an array of setting groups from the provided setting group instances.
     ///
     /// - Parameter settings: The setting group instances to include in the array.

--- a/Sources/DCSettings/Settings/DCSettingOption.swift
+++ b/Sources/DCSettings/Settings/DCSettingOption.swift
@@ -86,7 +86,7 @@ public struct DCSettingOption<ValueType>: Equatable where ValueType: Equatable {
 
     /// Initializes a new `DCSettingOption` instance with the specified value and default status.
     ///
-    /// This initializer creates a new instance of `DCSettingOption` with the label property being set to a string representation of the provided value.
+    /// This initializer creates a new instance of `DCSettingOption` with the label set to a string representation of the provided value.
     ///
     /// - Parameters:
     ///   - value: The value associated with the setting option conforming to `LosslessStringConvertible`.
@@ -180,7 +180,35 @@ public struct DCSettingOptionsBuilder {
     ///     - settings: A variadic list of `DCSettingOption` instances.
     ///
     /// - Returns: An array of `DCSettingOption` instances.
+    public static func buildBlock<ValueType>() -> [DCSettingOption<ValueType>] {
+        []
+    }
+
     public static func buildBlock<ValueType>(_ settings: DCSettingOption<ValueType>...) -> [DCSettingOption<ValueType>] {
         settings
+    }
+
+    public static func buildExpression<ValueType>(_ option: DCSettingOption<ValueType>?) -> [DCSettingOption<ValueType>] {
+        option.map { [$0] } ?? []
+    }
+
+    public static func buildBlock<ValueType>(_ components: [DCSettingOption<ValueType>]...) -> [DCSettingOption<ValueType>] {
+        components.flatMap { $0 }
+    }
+
+    public static func buildOptional<ValueType>(_ component: [DCSettingOption<ValueType>]?) -> [DCSettingOption<ValueType>] {
+        component ?? []
+    }
+
+    public static func buildEither<ValueType>(first component: [DCSettingOption<ValueType>]) -> [DCSettingOption<ValueType>] {
+        component
+    }
+
+    public static func buildEither<ValueType>(second component: [DCSettingOption<ValueType>]) -> [DCSettingOption<ValueType>] {
+        component
+    }
+
+    public static func buildArray<ValueType>(_ components: [[DCSettingOption<ValueType>]]) -> [DCSettingOption<ValueType>] {
+        components.flatMap { $0 }
     }
 }

--- a/Sources/DCSettings/Settings/DCSettingOption.swift
+++ b/Sources/DCSettings/Settings/DCSettingOption.swift
@@ -11,17 +11,17 @@ import Foundation
 /// Conforming types must be `CaseIterable` and `RawRepresentable` with a `RawValue` that conforms to `Equatable`.
 /// This protocol is typically used with an enumeration to provide a finite set of options for a `DCSetting`.
 public protocol DCSettingOptionProviding: CaseIterable, RawRepresentable where RawValue: Equatable {
-    
+
     /// The default case for the conforming type.
     ///
     /// If not provided, this property returns `nil`.
     static var defaultCase: Self? { get }
-    
+
     /// The label to display for the conforming type's case.
     ///
     /// If not provided, this property returns `nil`.
     var label: String? { get }
-    
+
     /// The image to display for the conforming type's case.
     ///
     /// If not provided, this property returns `nil`.
@@ -30,17 +30,17 @@ public protocol DCSettingOptionProviding: CaseIterable, RawRepresentable where R
 
 /// An extension that provides default implementations for the `DCSettingOptionProviding` protocol.
 public extension DCSettingOptionProviding {
-    
+
     /// The default case for the conforming type.
     ///
     /// This property returns `nil` by default.
     static var defaultCase: Self? { return nil }
-    
+
     /// The label to display for the conforming type's case.
     ///
     /// This property returns `nil` by default.
     var label: String? { return nil }
-    
+
     /// The image to display for the conforming type's case.
     ///
     /// This property returns `nil` by default.
@@ -64,26 +64,26 @@ public enum DCImageName: Equatable {
 ///
 /// - Note: The value type must conform to the `Equatable` protocol.
 public struct DCSettingOption<ValueType>: Equatable where ValueType: Equatable {
-    
+
     /// An optional label for the setting option.
     public let label: String?
-    
+
     /// An optional image for the setting option.
     public let image: DCImageName?
-    
+
     /// The value associated with the setting option.
     public let value: ValueType
-    
+
     /// A boolean value indicating whether the option is the default option.
     public let isDefault: Bool
-    
+
     init(value: ValueType, label: String?, image: DCImageName?, isDefault: Bool = false) {
         self.value = value
         self.label = label
         self.image = image
         self.isDefault = isDefault
     }
-    
+
     /// Initializes a new `DCSettingOption` instance with the specified value and default status.
     ///
     /// This initializer creates a new instance of `DCSettingOption` with the label property being set to a string representation of the provided value.
@@ -94,7 +94,7 @@ public struct DCSettingOption<ValueType>: Equatable where ValueType: Equatable {
     public init(value: ValueType, default isDefault: Bool = false) where ValueType: LosslessStringConvertible {
         self.init(value: value, label: String(value), image: nil, isDefault: isDefault)
     }
-    
+
     /// Initializes a new `DCSettingOption` instance with the specified value, label, and default status.
     ///
     /// - Parameters:
@@ -104,7 +104,7 @@ public struct DCSettingOption<ValueType>: Equatable where ValueType: Equatable {
     public init(value: ValueType, label: String, isDefault: Bool = false) {
         self.init(value: value, label: label, image: nil, isDefault: isDefault)
     }
-    
+
     /// Initializes a new `DCSettingOption` instance with the specified value, image, and default status.
     ///
     /// - Parameters:
@@ -114,7 +114,7 @@ public struct DCSettingOption<ValueType>: Equatable where ValueType: Equatable {
     public init(value: ValueType, image: String, isDefault: Bool = false) {
         self.init(value: value, label: nil, image: .custom(image), isDefault: isDefault)
     }
-    
+
     /// Initializes a new `DCSettingOption` instance with the specified value, system image, and default status.
     ///
     /// - Parameters:
@@ -124,7 +124,7 @@ public struct DCSettingOption<ValueType>: Equatable where ValueType: Equatable {
     public init(value: ValueType, systemImage: String, isDefault: Bool = false) {
         self.init(value: value, label: nil, image: .system(systemImage), isDefault: isDefault)
     }
-    
+
     /// Initializes a new `DCSettingOption` instance with the specified value, label, image, and default status.
     ///
     /// - Parameters:
@@ -135,7 +135,7 @@ public struct DCSettingOption<ValueType>: Equatable where ValueType: Equatable {
     public init(value: ValueType, label: String, image: String, isDefault: Bool = false) {
         self.init(value: value, label: label, image: .custom(image), isDefault: isDefault)
     }
-    
+
     /// Initializes a new `DCSettingOption` instance with the specified value, label, image, and default status.
     ///
     /// - Parameters:
@@ -149,7 +149,7 @@ public struct DCSettingOption<ValueType>: Equatable where ValueType: Equatable {
 }
 
 extension DCSettingOption {
-    
+
     /// Returns a new `DCSettingOption` instance with default status `true`.
     public func `default`() -> DCSettingOption {
         return DCSettingOption(value: value, label: label, image: image, isDefault: true)
@@ -170,7 +170,7 @@ extension DCSettingOption {
 /// ```
 @resultBuilder
 public struct DCSettingOptionsBuilder {
-    
+
     /// Constructs an array of `DCSettingOption` instances from the provided expressions.
     ///
     /// This method is called by the result builder to construct the final result from the provided expressions.

--- a/Sources/DCSettings/Settings/DCSettingsManager.swift
+++ b/Sources/DCSettings/Settings/DCSettingsManager.swift
@@ -44,7 +44,7 @@ public class DCSettingsManager {
     
     /// Configures the manager with an array of setting groups.
     ///
-    /// - Parameter groups: An array of `DCSettingGroup` values representing the setting groups to be managed by the manager.
+    /// - Parameter settingGroups: An array of `DCSettingGroup` values representing the setting groups to be managed by the manager.
     public func configure(groups settingGroups: [DCSettingGroup]) {
         groups = settingGroups
         for group in groups {

--- a/Sources/DCSettings/Settings/DCSettingsManager.swift
+++ b/Sources/DCSettings/Settings/DCSettingsManager.swift
@@ -31,7 +31,7 @@ import Combine
 /// let darkMode = manager.bool(forKey: "darkMode")
 /// manager.set(!darkMode, forKey: "darkMode")
 /// ```
-public class DCSettingsManager {
+@MainActor public class DCSettingsManager {
 
     /// A shared instance of `DCSettingsManager`.
     public static let shared = DCSettingsManager()
@@ -60,7 +60,7 @@ public class DCSettingsManager {
     ///
     /// - Parameter builder: A result builder that produces an array of `DCSettingGroup` values
     /// representing the setting groups to be managed by the manager.
-    public func configure(@DCSettingGroupsBuilder _ builder: () -> [DCSettingGroup]) {
+    public func configure(@DCSettingGroupsBuilder _ builder: @MainActor () -> [DCSettingGroup]) {
         configure(groups: builder())
     }
 
@@ -153,7 +153,7 @@ public class DCSettingsManager {
     ///
     /// - Returns: An `AnyPublisher` that emits the represented value of the setting with the specified key.
     /// Returns `nil` if the setting is not found or the represented value cannot be initialized from the raw value.
-    public func representedValuePublisher<ValueType>(forKey key: DCKeyRepresentable) -> AnyPublisher<ValueType?, Never>? where ValueType: RawRepresentable, ValueType.RawValue: Equatable{
+    public func representedValuePublisher<ValueType>(forKey key: DCKeyRepresentable) -> AnyPublisher<ValueType?, Never>? where ValueType: RawRepresentable, ValueType.RawValue: Equatable {
         guard let settable = setting(forKey: key) as? DCSetting<ValueType.RawValue> else {
             return nil
         }

--- a/Sources/DCSettings/Settings/DCSettingsManager.swift
+++ b/Sources/DCSettings/Settings/DCSettingsManager.swift
@@ -32,16 +32,16 @@ import Combine
 /// manager.set(!darkMode, forKey: "darkMode")
 /// ```
 public class DCSettingsManager {
-    
+
     /// A shared instance of `DCSettingsManager`.
     public static let shared = DCSettingsManager()
-    
+
     public private(set) var groups: [DCSettingGroup] = []
-    
+
     private var cancellables = Set<AnyCancellable>()
-    
+
     public init() {}
-    
+
     /// Configures the manager with an array of setting groups.
     ///
     /// - Parameter settingGroups: An array of `DCSettingGroup` values representing the setting groups to be managed by the manager.
@@ -55,7 +55,7 @@ public class DCSettingsManager {
             }
         }
     }
-    
+
     /// Configures the manager with a result builder that produces an array of setting groups.
     ///
     /// - Parameter builder: A result builder that produces an array of `DCSettingGroup` values
@@ -63,7 +63,7 @@ public class DCSettingsManager {
     public func configure(@DCSettingGroupsBuilder _ builder: () -> [DCSettingGroup]) {
         configure(groups: builder())
     }
-    
+
     /// Sets the value for a setting with the specified key.
     ///
     /// - Parameters:
@@ -88,7 +88,7 @@ public class DCSettingsManager {
         let existingSettings = groups.flatMap({ $0.settings })
         return existingSettings.first(where: { $0.key == key.keyValue })
     }
-    
+
     /// Returns the value for a setting with the specified key.
     ///
     /// - Parameter key: The key of the desired setting value.
@@ -98,7 +98,7 @@ public class DCSettingsManager {
         let setting = setting(forKey: key) as? DCSetting<ValueType>
         return setting?.value
     }
-    
+
     /// Returns the represented value for a setting with the specified key.
     ///
     /// This method is useful when working with settings that have raw representable values such as enums or option sets.
@@ -113,7 +113,7 @@ public class DCSettingsManager {
         }
         return nil
     }
-    
+
     /// Returns a binding to the value for a setting with the specified key.
     ///
     /// - Parameter key: The key of the desired setting value.
@@ -129,7 +129,7 @@ public class DCSettingsManager {
         }
         return nil
     }
-    
+
     /// Returns a publisher that emits the current value of the setting with the specified key.
     ///
     /// - Parameters:
@@ -145,7 +145,7 @@ public class DCSettingsManager {
             .merge(with: settable.objectWillChange.map { settable.value })
             .eraseToAnyPublisher()
     }
-    
+
     /// Returns a publisher that emits the represented value of the setting with the specified key.
     ///
     /// - Parameters:
@@ -161,7 +161,7 @@ public class DCSettingsManager {
             .merge(with: settable.objectWillChange.map { ValueType(rawValue: settable.value) })
             .eraseToAnyPublisher()
     }
-    
+
     /// Returns a boolean value for the setting with the specified key.
     ///
     /// - Parameter key: The key of the desired setting value.
@@ -170,7 +170,7 @@ public class DCSettingsManager {
     public func bool(forKey key: DCKeyRepresentable) -> Bool {
         return value(forKey: key) ?? false
     }
-    
+
     /// Returns an integer value for the setting with the specified key.
     ///
     /// - Parameter key: The key of the desired setting value.
@@ -179,7 +179,7 @@ public class DCSettingsManager {
     public func int(forKey key: DCKeyRepresentable) -> Int {
         return value(forKey: key) ?? 0
     }
-    
+
     /// Returns a double value for the setting with the specified key.
     ///
     /// - Parameter key: The key of the desired setting value.
@@ -188,7 +188,7 @@ public class DCSettingsManager {
     public func double(forKey key: DCKeyRepresentable) -> Double {
         return value(forKey: key) ?? 0.0
     }
-    
+
     /// Returns a string value for the setting with the specified key.
     ///
     /// - Parameter key: The key of the desired setting value.
@@ -197,7 +197,7 @@ public class DCSettingsManager {
     public func string(forKey key: DCKeyRepresentable) -> String {
         return value(forKey: key) ?? ""
     }
-    
+
     /// Returns a date value for the setting with the specified key.
     ///
     /// - Parameter key: The key of the desired setting value.
@@ -206,7 +206,7 @@ public class DCSettingsManager {
     public func date(forKey key: DCKeyRepresentable) -> Date {
         return value(forKey: key) ?? .distantPast
     }
-    
+
     /// Returns a color value for the setting with the specified key.
     ///
     /// - Parameter key: The key of the desired setting value.

--- a/Sources/DCSettings/Settings/DCSettingsManager.swift
+++ b/Sources/DCSettings/Settings/DCSettingsManager.swift
@@ -22,7 +22,7 @@ import Combine
 ///
 /// // Configure the manager with setting groups
 /// manager.configure {
-///     DCSettingGroup(label: "General") {
+///     DCSettingGroup("General") {
 ///         DCSetting(key: "darkMode", defaultValue: false)
 ///     }
 /// }
@@ -38,7 +38,7 @@ import Combine
 
     public private(set) var groups: [DCSettingGroup] = []
 
-    private var cancellables = Set<AnyCancellable>()
+    private var settingsByKey: [String: any DCSettable] = [:]
 
     public init() {}
 
@@ -47,11 +47,15 @@ import Combine
     /// - Parameter settingGroups: An array of `DCSettingGroup` values representing the setting groups to be managed by the manager.
     public func configure(groups settingGroups: [DCSettingGroup]) {
         groups = settingGroups
+        settingsByKey = [:]
         for group in groups {
             for setting in group.settings {
                 let store = setting.store ?? group.store
                 setting.store = store
                 setting.refresh()
+                if settingsByKey[setting.key] == nil {
+                    settingsByKey[setting.key] = setting
+                }
             }
         }
     }
@@ -74,7 +78,7 @@ import Combine
     @discardableResult public func set<ValueType>(_ value: ValueType, forKey key: DCKeyRepresentable) -> Bool where ValueType: Equatable {
         if let setting = setting(forKey: key) as? DCSetting<ValueType> {
             setting.value = value
-            return true
+            return setting.value == value
         }
         return false
     }
@@ -85,8 +89,7 @@ import Combine
     ///
     /// - Returns: The desired `(any DCSettable)` if it has been configured by the manager, otherwise returns `nil`.
     public func setting(forKey key: DCKeyRepresentable) -> (any DCSettable)? {
-        let existingSettings = groups.flatMap({ $0.settings })
-        return existingSettings.first(where: { $0.key == key.keyValue })
+        return settingsByKey[key.keyValue]
     }
 
     /// Returns the value for a setting with the specified key.
@@ -106,7 +109,7 @@ import Combine
     ///
     /// - Parameter key: The key of the desired setting value.
     ///
-    /// - Returns: The desired represented value has been configured by the manager and can be converted, otherwise returns `nil`.
+    /// - Returns: The desired represented value if it has been configured by the manager and can be converted, otherwise returns `nil`.
     public func representedValue<ValueType>(forKey key: DCKeyRepresentable) -> ValueType? where ValueType: RawRepresentable, ValueType.RawValue: Equatable {
         if let settingRawValue: ValueType.RawValue = value(forKey: key), let option = ValueType(rawValue: settingRawValue) {
             return option
@@ -136,7 +139,7 @@ import Combine
     ///   - key: The key for the value to observe.
     ///
     /// - Returns: An `AnyPublisher` that emits the current value of the setting with the specified key.
-    /// Returns `nil` if the setting is not found or the value not of the expected type.
+    /// Returns `nil` if the setting is not found or the value is not of the expected type.
     public func valuePublisher<ValueType>(forKey key: DCKeyRepresentable) -> AnyPublisher<ValueType, Never>? where ValueType: Equatable {
         guard let settable = setting(forKey: key) as? DCSetting<ValueType> else {
             return nil
@@ -166,7 +169,7 @@ import Combine
     ///
     /// - Parameter key: The key of the desired setting value.
     ///
-    /// - Returns: The desired boolean value if has been configured by the manager, otherwise returns `false`.
+    /// - Returns: The desired boolean value if it has been configured by the manager, otherwise returns `false`.
     public func bool(forKey key: DCKeyRepresentable) -> Bool {
         return value(forKey: key) ?? false
     }

--- a/Sources/DCSettings/Settings/DCSettingsManager.swift
+++ b/Sources/DCSettings/Settings/DCSettingsManager.swift
@@ -141,9 +141,9 @@ public class DCSettingsManager {
         guard let settable = setting(forKey: key) as? DCSetting<ValueType> else {
             return nil
         }
-        return settable.objectWillChange
-           .map { settable.value }
-           .eraseToAnyPublisher()
+        return Just(settable.value)
+            .merge(with: settable.objectWillChange.map { settable.value })
+            .eraseToAnyPublisher()
     }
     
     /// Returns a publisher that emits the represented value of the setting with the specified key.
@@ -157,9 +157,9 @@ public class DCSettingsManager {
         guard let settable = setting(forKey: key) as? DCSetting<ValueType.RawValue> else {
             return nil
         }
-        return settable.objectWillChange
-           .map { ValueType(rawValue: settable.value) }
-           .eraseToAnyPublisher()
+        return Just(ValueType(rawValue: settable.value))
+            .merge(with: settable.objectWillChange.map { ValueType(rawValue: settable.value) })
+            .eraseToAnyPublisher()
     }
     
     /// Returns a boolean value for the setting with the specified key.

--- a/Sources/DCSettings/Settings/DCStoredRepresentedValue.swift
+++ b/Sources/DCSettings/Settings/DCStoredRepresentedValue.swift
@@ -13,7 +13,7 @@ import SwiftUI
 /// This is useful when working with settings that have raw representable values such as enums or option sets.
 ///
 /// When the wrapped value is accessed or modified, the value will be automatically loaded from or saved to the store using a `DCSetting` instance.
-@propertyWrapper
+@MainActor @propertyWrapper
 public struct DCStoredRepresentedValue<ValueType>: DynamicProperty where ValueType: RawRepresentable, ValueType.RawValue: Equatable {
 
     @StateObject private var setting: DCSetting<ValueType.RawValue>

--- a/Sources/DCSettings/Settings/DCStoredRepresentedValue.swift
+++ b/Sources/DCSettings/Settings/DCStoredRepresentedValue.swift
@@ -34,8 +34,8 @@ public struct DCStoredRepresentedValue<ValueType>: DynamicProperty where ValueTy
 
     /// Initializes a new `DCStoredRepresentedValue` instance with the specified key and settings manager.
     ///
-    /// This initializer creates a new instance of `DCStoredRepresentedValue` with the specified key, and settings manager.
-    /// The key and default value are required, while the settings manager is optional and defaults to the `.shared` singleton instance.
+    /// This initializer creates a new instance of `DCStoredRepresentedValue` with the specified key and settings manager.
+    /// The key is required, while the settings manager is optional and defaults to the `.shared` singleton instance.
     ///
     /// If a `DCSetting` instance with the specified key already exists in the settings manager, it will be used to initialize the `StateObject` property.
     /// Otherwise, a runtime error will occur.

--- a/Sources/DCSettings/Settings/DCStoredRepresentedValue.swift
+++ b/Sources/DCSettings/Settings/DCStoredRepresentedValue.swift
@@ -13,7 +13,6 @@ import SwiftUI
 /// This is useful when working with settings that have raw representable values such as enums or option sets.
 ///
 /// When the wrapped value is accessed or modified, the value will be automatically loaded from or saved to the store using a `DCSetting` instance.
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
 @propertyWrapper
 public struct DCStoredRepresentedValue<ValueType>: DynamicProperty where ValueType: RawRepresentable, ValueType.RawValue: Equatable {
     

--- a/Sources/DCSettings/Settings/DCStoredRepresentedValue.swift
+++ b/Sources/DCSettings/Settings/DCStoredRepresentedValue.swift
@@ -15,7 +15,7 @@ import SwiftUI
 /// When the wrapped value is accessed or modified, the value will be automatically loaded from or saved to the store using a `DCSetting` instance.
 @propertyWrapper
 public struct DCStoredRepresentedValue<ValueType>: DynamicProperty where ValueType: RawRepresentable, ValueType.RawValue: Equatable {
-    
+
     @StateObject private var setting: DCSetting<ValueType.RawValue>
 
     /// The current represented value of the wrapped property.

--- a/Sources/DCSettings/Settings/DCStoredValue.swift
+++ b/Sources/DCSettings/Settings/DCStoredValue.swift
@@ -22,7 +22,7 @@ import SwiftUI
 /// ```
 @propertyWrapper
 public struct DCStoredValue<ValueType>: DynamicProperty where ValueType: Equatable {
-    
+
     @StateObject private var setting: DCSetting<ValueType>
 
     /// The current value of the wrapped property.
@@ -60,7 +60,7 @@ public struct DCStoredValue<ValueType>: DynamicProperty where ValueType: Equatab
             fatalError("[DCStoredValue] No value of specified type found for key \(key.keyValue). Settings need to be configured in the specified settings manager before use.")
         }
     }
-    
+
     /// A binding to the current value of the wrapped property.
     ///
     /// The `projectedValue` property provides a `Binding` to the current value of the wrapped property.

--- a/Sources/DCSettings/Settings/DCStoredValue.swift
+++ b/Sources/DCSettings/Settings/DCStoredValue.swift
@@ -40,7 +40,7 @@ public struct DCStoredValue<ValueType>: DynamicProperty where ValueType: Equatab
     /// Initializes a new `DCStoredValue` instance with the specified key and settings manager.
     ///
     /// This initializer creates a new instance of `DCStoredValue` with the specified key and settings manager.
-    /// The key and default value are required, while the settings manager is optional and defaults to the `.shared` singleton instance.
+    /// The key is required, while the settings manager is optional and defaults to the `.shared` singleton instance.
     ///
     /// If a `DCSetting` instance with the specified key already exists in the settings manager, it will be used to initialize the `StateObject` property.
     /// Otherwise, a runtime error will occur.

--- a/Sources/DCSettings/Settings/DCStoredValue.swift
+++ b/Sources/DCSettings/Settings/DCStoredValue.swift
@@ -20,7 +20,7 @@ import SwiftUI
 ///
 /// @DCStoredValue("key3") var value3: Bool
 /// ```
-@propertyWrapper
+@MainActor @propertyWrapper
 public struct DCStoredValue<ValueType>: DynamicProperty where ValueType: Equatable {
 
     @StateObject private var setting: DCSetting<ValueType>

--- a/Sources/DCSettings/Settings/DCStoredValue.swift
+++ b/Sources/DCSettings/Settings/DCStoredValue.swift
@@ -20,7 +20,6 @@ import SwiftUI
 ///
 /// @DCStoredValue("key3") var value3: Bool
 /// ```
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
 @propertyWrapper
 public struct DCStoredValue<ValueType>: DynamicProperty where ValueType: Equatable {
     

--- a/Sources/DCSettings/Settings/DCValueBounds.swift
+++ b/Sources/DCSettings/Settings/DCValueBounds.swift
@@ -11,10 +11,10 @@ import Foundation
 /// The `DCValueBounds` struct is used to represent a range of values with a lower and upper bound.
 /// The value type must conform to the `Equatable` protocol.
 public struct DCValueBounds<ValueType>: Equatable where ValueType: Equatable {
-    
+
     /// The lower bound of the range.
     public let lowerBound: ValueType
-    
+
     /// The upper bound of the range.
     public let upperBound: ValueType
 }

--- a/Sources/DCSettings/Store/DCKeyValueStore.swift
+++ b/Sources/DCSettings/Store/DCKeyValueStore.swift
@@ -8,66 +8,66 @@ import Combine
 
 /// A protocol that defines an interface for a key-value store.
 public protocol DCKeyValueStore {
-    
+
     /// Returns a publisher that emits the value for the given key whenever it changes.
     ///
     /// - Parameter key: The key for the value to observe.
     /// - Returns: A publisher that emits the value for the given key whenever it changes.
     func valuePublisher(forKey key: String) -> AnyPublisher<Any?, Never>
-    
+
     /// Sets the value of the specified key in the key-value store.
     ///
     /// - Parameters:
     ///   - value: The value to store in the key-value store.
     ///   - key: The key with which to associate the value.
     func set(_ value: Any?, forKey key: String)
-    
+
     /// Returns the value associated with the specified key.
     ///
     /// - Parameter key: A key in the key-value store.
     /// - Returns: The value associated with the specified key, or `nil` if the key does not exist.
     func object(forKey key: String) -> Any?
-    
+
     /// Sets a boolean value for the specified key in the key-value store.
     ///
     /// - Parameters:
     ///   - value: The boolean value to store in the key-value store.
     ///   - key: The key with which to associate the value.
     func set(_ value: Bool, forKey key: String)
-    
+
     /// Returns a boolean value associated with the specified key.
     ///
     /// - Parameter key: A key in the key-value store.
     /// - Returns: The boolean value associated with the specified key, or `false` if the key does not exist or its value is not a boolean.
     func bool(forKey key: String) -> Bool
-    
+
     /// Sets an integer value for the specified key in the key-value store.
     ///
     /// - Parameters:
     ///   - value: The integer value to store in the key-value store.
     ///   - key: The key with which to associate the value.
     func set(_ value: Int, forKey key: String)
-    
+
     /// Returns an integer value associated with the specified key.
     ///
     /// - Parameter key: A key in the key-value store.
     /// - Returns: The integer value associated with the specified key, or `0` if the key does not exist or its value is not an integer.
     func integer(forKey key: String) -> Int
-    
+
     /// Sets a double-precision floating-point value for the specified key in the key-value store.
     ///
     /// - Parameters:
     ///   - value: The double-precision floating-point value to store in the key-value store.
     ///   - key: The key with which to associate the value.
     func set(_ value: Double, forKey key: String)
-    
+
     /// Returns a double-precision floating-point value associated with the specified key.
     ///
     /// - Parameter key: A key in the key-value store.
     /// - Returns: The double-precision floating-point value associated with the specified key,
     /// or `0.0` if the key does not exist or its value is not a double-precision floating-point number.
     func double(forKey key: String) -> Double
-    
+
     /// Returns a string associated with the specified key.
     ///
     /// - Parameter key: A key in the key-value store.

--- a/Sources/DCSettings/Store/DCSettingStore.swift
+++ b/Sources/DCSettings/Store/DCSettingStore.swift
@@ -19,6 +19,9 @@ public enum DCSettingStore {
     case userDefaults(suiteName: String)
     
     /// A key-value store that uses the iCloud `NSUbiquitousKeyValueStore` key-value store.
+    ///
+    /// On watchOS, this store is available in watchOS 9.0 or newer.
+    @available(watchOS 9.0, *)
     case ubiquitous
     
     /// A custom key-value store that conforms to the `DCKeyValueStore` protocol.
@@ -37,9 +40,8 @@ public enum DCSettingStore {
                 if #available(watchOS 9.0, *) {
                     return NSUbiquitousKeyValueStore.default
                 }
-                else {
-                    fatalError("[DCSettingStore] 'NSUbiquitousKeyValueStore' is only available in watchOS 9.0 or newer")
-                }
+                
+                return UserDefaults.standard
             #else
                 return NSUbiquitousKeyValueStore.default
             #endif

--- a/Sources/DCSettings/Store/DCSettingStore.swift
+++ b/Sources/DCSettings/Store/DCSettingStore.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 import Combine
+import SwiftUI
 
 private let userDefaultsCache = UserDefaultsCache()
 
@@ -95,8 +96,8 @@ public enum DCSettingStore {
 
     /// Sets the value of the specified key in the key-value store.
     ///
-    /// Standard property-list compatible values are stored directly. Other values
-    /// must conform to `Codable` and are stored as JSON-encoded `Data`.
+    /// Standard property-list compatible values are stored directly. `Color` values
+    /// and other `Codable` values are stored as JSON-encoded `Data`.
     ///
     /// - Parameters:
     ///   - value: The value to store in the key-value store.
@@ -113,6 +114,18 @@ public enum DCSettingStore {
             return true
         }
 
+        if let color = value as? Color {
+            do {
+                let data = try color.dcSettingsEncodedData()
+                backingStore.set(data, forKey: key)
+                return true
+            }
+            catch {
+                assertionFailure("[DCSettingStore] Failed to encode color for key '\(key)': \(error)")
+                return false
+            }
+        }
+
         if let codableValue = value as? Codable {
             do {
                 let data = try JSONEncoder().encode(codableValue)
@@ -125,7 +138,7 @@ public enum DCSettingStore {
             }
         }
 
-        assertionFailure("[DCSettingStore] Unsupported value for key '\(key)'. Values must be property-list compatible or Codable.")
+        assertionFailure("[DCSettingStore] Unsupported value for key '\(key)'. Values must be property-list compatible, Color, or Codable.")
         return false
     }
 
@@ -204,6 +217,10 @@ public enum DCSettingStore {
     private func decodedValue<ValueType>(_ object: Any?, as type: ValueType.Type) -> ValueType? {
         if let value = object as? ValueType {
             return value
+        }
+
+        if ValueType.self == Color.self, let data = object as? Data, let color = try? Color(dcSettingsData: data) {
+            return color as? ValueType
         }
 
         if let data = object as? Data, let decodableType = ValueType.self as? Decodable.Type {

--- a/Sources/DCSettings/Store/DCSettingStore.swift
+++ b/Sources/DCSettings/Store/DCSettingStore.swift
@@ -9,26 +9,26 @@ import Combine
 
 /// An enumeration that represents different types of key-value stores.
 public enum DCSettingStore {
-    
+
     /// The standard `UserDefaults` key-value store.
     case standard
-    
+
     /// A `UserDefaults` key-value store with the specified suite name.
     ///
     /// - Parameter suiteName: The suite name of the `UserDefaults` store to use.
     case userDefaults(suiteName: String)
-    
+
     /// A key-value store that uses the iCloud `NSUbiquitousKeyValueStore` key-value store.
     ///
     /// On watchOS, this store is available in watchOS 9.0 or newer.
     @available(watchOS 9.0, *)
     case ubiquitous
-    
+
     /// A custom key-value store that conforms to the `DCKeyValueStore` protocol.
     ///
     /// - Parameter backingStore: The custom key-value store to use.
     case custom(backingStore: DCKeyValueStore)
-    
+
     private var backingStore: DCKeyValueStore {
         switch self {
         case .standard:
@@ -40,7 +40,7 @@ public enum DCSettingStore {
                 if #available(watchOS 9.0, *) {
                     return NSUbiquitousKeyValueStore.default
                 }
-                
+
                 return UserDefaults.standard
             #else
                 return NSUbiquitousKeyValueStore.default
@@ -49,7 +49,7 @@ public enum DCSettingStore {
             return backingStore
         }
     }
-    
+
     /// Returns a publisher that emits the value for the given key whenever it changes.
     ///
     /// - Parameter key: The key for the value to observe.
@@ -57,7 +57,7 @@ public enum DCSettingStore {
     public func valuePublisher(forKey key: String) -> AnyPublisher<Any?, Never> {
         return backingStore.valuePublisher(forKey: key)
     }
-    
+
     /// Returns a publisher that emits the typed value for the given key whenever it changes.
     ///
     /// - Parameters:
@@ -71,21 +71,43 @@ public enum DCSettingStore {
             }
             .eraseToAnyPublisher()
     }
-    
+
     /// Sets the value of the specified key in the key-value store.
+    ///
+    /// Standard property-list compatible values are stored directly. Other values
+    /// must conform to `Encodable` and are stored as JSON-encoded `Data`.
     ///
     /// - Parameters:
     ///   - value: The value to store in the key-value store.
     ///   - key: The key with which to associate the value.
-    public func set<ValueType>(_ value: ValueType?, forKey key: String) {
+    /// - Returns: `true` when the value could be stored, otherwise `false`.
+    @discardableResult public func set<ValueType>(_ value: ValueType?, forKey key: String) -> Bool {
+        guard let value else {
+            backingStore.set(nil, forKey: key)
+            return true
+        }
+
         if isStandardType(ValueType.self) {
             backingStore.set(value, forKey: key)
+            return true
         }
-        else if let encodableValue = value as? Encodable, let data = try? JSONEncoder().encode(encodableValue) {
-            backingStore.set(data, forKey: key)
+
+        if let encodableValue = value as? Encodable {
+            do {
+                let data = try JSONEncoder().encode(encodableValue)
+                backingStore.set(data, forKey: key)
+                return true
+            }
+            catch {
+                assertionFailure("[DCSettingStore] Failed to encode value for key '\(key)': \(error)")
+                return false
+            }
         }
+
+        assertionFailure("[DCSettingStore] Unsupported value for key '\(key)'. Values must be property-list compatible or Encodable.")
+        return false
     }
-    
+
     /// Returns the value associated with the specified key.
     ///
     /// - Parameter key: A key in the key-value store.
@@ -93,7 +115,7 @@ public enum DCSettingStore {
     public func object<ValueType>(forKey key: String) -> ValueType? {
         return decodedValue(backingStore.object(forKey: key), as: ValueType.self)
     }
-    
+
     /// Sets a boolean value for the specified key in the key-value store.
     ///
     /// - Parameters:
@@ -102,7 +124,7 @@ public enum DCSettingStore {
     public func set(_ value: Bool, forKey key: String) {
         backingStore.set(value, forKey: key)
     }
-    
+
     /// Returns a boolean value associated with the specified key.
     ///
     /// - Parameter key: A key in the key-value store.
@@ -110,7 +132,7 @@ public enum DCSettingStore {
     public func bool(forKey key: String) -> Bool {
         return backingStore.bool(forKey: key)
     }
-    
+
     /// Sets an integer value for the specified key in the key-value store.
     ///
     /// - Parameters:
@@ -119,7 +141,7 @@ public enum DCSettingStore {
     public func set(_ value: Int, forKey key: String) {
         backingStore.set(value, forKey: key)
     }
-    
+
     /// Returns an integer value associated with the specified key.
     ///
     /// - Parameter key: A key in the key-value store.
@@ -127,7 +149,7 @@ public enum DCSettingStore {
     public func integer(forKey key: String) -> Int {
         return backingStore.integer(forKey: key)
     }
-    
+
     /// Sets a double-precision floating-point value for the specified key in the key-value store.
     ///
     /// - Parameters:
@@ -136,7 +158,7 @@ public enum DCSettingStore {
     public func set(_ value: Double, forKey key: String) {
         backingStore.set(value, forKey: key)
     }
-    
+
     /// Returns a double-precision floating-point value associated with the specified key.
     ///
     /// - Parameter key:  A key in the key-value store.
@@ -145,7 +167,7 @@ public enum DCSettingStore {
     public func double(forKey key: String) -> Double {
         return backingStore.double(forKey: key)
     }
-    
+
     /// Returns a string associated with the specified key.
     ///
     /// - Parameter key: A key in the key-value store.
@@ -153,21 +175,21 @@ public enum DCSettingStore {
     public func string(forKey key: String) -> String? {
         return backingStore.string(forKey: key)
     }
-    
+
     private func isStandardType<T>(_ type: T.Type) -> Bool {
         return type == Bool.self || type == Int.self || type == Double.self || type == String.self || type == Date.self || type == Data.self
     }
-    
+
     private func decodedValue<ValueType>(_ object: Any?, as type: ValueType.Type) -> ValueType? {
         if let value = object as? ValueType {
             return value
         }
-        
+
         if let data = object as? Data, let decodableType = ValueType.self as? Decodable.Type {
             let value = try? JSONDecoder().decode(decodableType, from: data)
             return value as? ValueType
         }
-        
+
         return nil
     }
 }

--- a/Sources/DCSettings/Store/DCSettingStore.swift
+++ b/Sources/DCSettings/Store/DCSettingStore.swift
@@ -10,15 +10,15 @@ import Combine
 /// An enumeration that represents different types of key-value stores.
 public enum DCSettingStore {
     
-    /// The standard `UserDeafults` key-value store.
+    /// The standard `UserDefaults` key-value store.
     case standard
     
-    /// A `UserDeafults` key-value store with the specified suite name.
+    /// A `UserDefaults` key-value store with the specified suite name.
     ///
-    /// - Parameter suiteName: The suite name of the `UserDeafults` store to use.
+    /// - Parameter suiteName: The suite name of the `UserDefaults` store to use.
     case userDefaults(suiteName: String)
     
-    /// A key-value store that uses the iCloud  `NSUbiquitousKeyValueStore` key-value store.
+    /// A key-value store that uses the iCloud `NSUbiquitousKeyValueStore` key-value store.
     case ubiquitous
     
     /// A custom key-value store that conforms to the `DCKeyValueStore` protocol.
@@ -56,6 +56,20 @@ public enum DCSettingStore {
         return backingStore.valuePublisher(forKey: key)
     }
     
+    /// Returns a publisher that emits the typed value for the given key whenever it changes.
+    ///
+    /// - Parameters:
+    ///   - key: The key for the value to observe.
+    ///   - type: The expected value type.
+    /// - Returns: A publisher that emits decoded typed values for the given key whenever it changes.
+    public func valuePublisher<ValueType>(forKey key: String, as type: ValueType.Type) -> AnyPublisher<ValueType?, Never> {
+        return valuePublisher(forKey: key)
+            .map { object in
+                decodedValue(object, as: type)
+            }
+            .eraseToAnyPublisher()
+    }
+    
     /// Sets the value of the specified key in the key-value store.
     ///
     /// - Parameters:
@@ -75,19 +89,7 @@ public enum DCSettingStore {
     /// - Parameter key: A key in the key-value store.
     /// - Returns: The value associated with the specified key, or `nil` if the key does not exist.
     public func object<ValueType>(forKey key: String) -> ValueType? {
-        if case .custom = self {
-            return backingStore.object(forKey: key) as? ValueType
-        }
-        
-        let object = backingStore.object(forKey: key)
-        if isStandardType(ValueType.self) {
-            return backingStore.object(forKey: key) as? ValueType
-        }
-        else if let data = object as? Data, let decodableType = ValueType.self as? Decodable.Type {
-            let value = try? JSONDecoder().decode(decodableType, from: data)
-            return value as? ValueType
-        }
-        return nil
+        return decodedValue(backingStore.object(forKey: key), as: ValueType.self)
     }
     
     /// Sets a boolean value for the specified key in the key-value store.
@@ -152,5 +154,18 @@ public enum DCSettingStore {
     
     private func isStandardType<T>(_ type: T.Type) -> Bool {
         return type == Bool.self || type == Int.self || type == Double.self || type == String.self || type == Date.self || type == Data.self
+    }
+    
+    private func decodedValue<ValueType>(_ object: Any?, as type: ValueType.Type) -> ValueType? {
+        if let value = object as? ValueType {
+            return value
+        }
+        
+        if let data = object as? Data, let decodableType = ValueType.self as? Decodable.Type {
+            let value = try? JSONDecoder().decode(decodableType, from: data)
+            return value as? ValueType
+        }
+        
+        return nil
     }
 }

--- a/Sources/DCSettings/Store/DCSettingStore.swift
+++ b/Sources/DCSettings/Store/DCSettingStore.swift
@@ -7,6 +7,27 @@
 import Foundation
 import Combine
 
+private let userDefaultsCache = UserDefaultsCache()
+
+private final class UserDefaultsCache: @unchecked Sendable {
+
+    private let lock = NSLock()
+    private var stores: [String: UserDefaults] = [:]
+
+    func userDefaults(suiteName: String) -> UserDefaults? {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let store = stores[suiteName] {
+            return store
+        }
+
+        let store = UserDefaults(suiteName: suiteName)
+        stores[suiteName] = store
+        return store
+    }
+}
+
 /// An enumeration that represents different types of key-value stores.
 public enum DCSettingStore {
 
@@ -34,7 +55,7 @@ public enum DCSettingStore {
         case .standard:
             return UserDefaults.standard
         case .userDefaults(let suiteName):
-            return UserDefaults.init(suiteName: suiteName) ?? .standard
+            return userDefaultsCache.userDefaults(suiteName: suiteName) ?? .standard
         case .ubiquitous:
             #if os(watchOS)
                 if #available(watchOS 9.0, *) {
@@ -75,7 +96,7 @@ public enum DCSettingStore {
     /// Sets the value of the specified key in the key-value store.
     ///
     /// Standard property-list compatible values are stored directly. Other values
-    /// must conform to `Encodable` and are stored as JSON-encoded `Data`.
+    /// must conform to `Codable` and are stored as JSON-encoded `Data`.
     ///
     /// - Parameters:
     ///   - value: The value to store in the key-value store.
@@ -92,9 +113,9 @@ public enum DCSettingStore {
             return true
         }
 
-        if let encodableValue = value as? Encodable {
+        if let codableValue = value as? Codable {
             do {
-                let data = try JSONEncoder().encode(encodableValue)
+                let data = try JSONEncoder().encode(codableValue)
                 backingStore.set(data, forKey: key)
                 return true
             }
@@ -104,7 +125,7 @@ public enum DCSettingStore {
             }
         }
 
-        assertionFailure("[DCSettingStore] Unsupported value for key '\(key)'. Values must be property-list compatible or Encodable.")
+        assertionFailure("[DCSettingStore] Unsupported value for key '\(key)'. Values must be property-list compatible or Codable.")
         return false
     }
 

--- a/Sources/DCSettings/Views/DCSettingView.swift
+++ b/Sources/DCSettings/Views/DCSettingView.swift
@@ -7,7 +7,7 @@
 import SwiftUI
 
 extension DCSetting {
-    
+
     var displayLabel: String {
         return label ?? key.sentenceFormatted
     }
@@ -16,14 +16,14 @@ extension DCSetting {
 enum DCOptionControlStyle: Equatable {
     case picker
     case menuPicker
-    
+
     init(optionCount: Int) {
         self = optionCount > 2 ? .menuPicker : .picker
     }
 }
 
 extension DCSettingOption {
-    
+
     public func labelView() -> some View {
         return HStack {
             if let string = label {
@@ -53,9 +53,9 @@ extension DCSettingOption {
 
 struct DCBoolSettingView: View {
     @Environment(\.isEnabled) var isEnabled
-    
+
     @ObservedObject var setting: DCSetting<Bool>
-    
+
     var body: some View {
         Toggle(setting.displayLabel, isOn: $setting.value)
             .toggleStyle(SwitchToggleStyle())
@@ -69,9 +69,9 @@ struct DCBoolSettingView: View {
 
 struct DCIntSettingView: View {
     @Environment(\.isEnabled) var isEnabled
-    
+
     @ObservedObject var setting: DCSetting<Int>
-    
+
     var body: some View {
         if let options = setting.configuration?.options {
             DCOptionPickerView(key: setting.key, label: setting.displayLabel, options: options, value: $setting.value)
@@ -105,7 +105,7 @@ struct DCIntSettingView: View {
                             }
                             .accessibilityLabel("Decrease \(setting.displayLabel)")
                             .accessibilityIdentifier("\(setting.key).decrement")
-                            
+
                             Button {
                                 setting.value += 1
                             } label: {
@@ -128,7 +128,7 @@ struct DCIntSettingView: View {
 
 struct DCDoubleSettingView: View {
     @ObservedObject var setting: DCSetting<Double>
-    
+
     var body: some View {
         if let options = setting.configuration?.options {
             DCOptionPickerView(key: setting.key, label: setting.displayLabel, options: options, value: $setting.value)
@@ -141,9 +141,9 @@ struct DCDoubleSettingView: View {
 
 struct DCStringSettingView: View {
     @Environment(\.isEnabled) var isEnabled
-    
+
     @ObservedObject var setting: DCSetting<String>
-    
+
     var body: some View {
         if let options = setting.configuration?.options {
             DCOptionPickerView(key: setting.key, label: setting.displayLabel, options: options, value: $setting.value)
@@ -158,13 +158,13 @@ struct DCStringSettingView: View {
 
 struct DCDateSettingView: View {
     @Environment(\.isEnabled) var isEnabled
-    
+
     @ObservedObject var setting: DCSetting<Date>
-    
+
     static func datePickerRange(for bounds: DCValueBounds<Date>) -> ClosedRange<Date> {
         return bounds.lowerBound...bounds.upperBound
     }
-    
+
     var body: some View {
         #if os(watchOS)
             // TODO: watchOS implementation
@@ -190,9 +190,9 @@ struct DCDateSettingView: View {
 
 struct DCColorSettingView: View {
     @Environment(\.isEnabled) var isEnabled
-    
+
     @ObservedObject var setting: DCSetting<Color>
-    
+
     var body: some View {
         #if os(watchOS)
             // TODO: watchOS implementation
@@ -207,14 +207,14 @@ struct DCColorSettingView: View {
 
 struct DCSliderView: View {
     @Environment(\.isEnabled) var isEnabled
-    
+
     let key: String
     let label: String
     @Binding var value: Double
     let bounds: DCValueBounds<Double>?
     let step: Double?
     let specifier: String
-    
+
     var body: some View {
         VStack {
             HStack {
@@ -270,12 +270,12 @@ struct DCSliderView: View {
 
 struct DCOptionPickerView<ValueType>: View where ValueType: Equatable & Hashable {
     @Environment(\.isEnabled) var isEnabled
-    
+
     let key: String
     let label: String
     let options: [DCSettingOption<ValueType>]
     @Binding var value: ValueType
-    
+
     var body: some View {
         if DCOptionControlStyle(optionCount: options.count) == .menuPicker {
             DCMenuPickerView(key: key, label: label, options: options, value: $value)
@@ -307,12 +307,12 @@ struct DCOptionPickerView<ValueType>: View where ValueType: Equatable & Hashable
 
 struct DCMenuPickerView<ValueType>: View where ValueType: Equatable & Hashable {
     @Environment(\.isEnabled) var isEnabled
-    
+
     let key: String
     let label: String
     let options: [DCSettingOption<ValueType>]
     @Binding var value: ValueType
-    
+
     var body: some View {
         HStack {
             Text(label)
@@ -375,9 +375,9 @@ struct DCMenuPickerView<ValueType>: View where ValueType: Equatable & Hashable {
 ///
 /// Supported types are: `Bool`, `Int`,  `Double`, `String`, `Date` and `Color`.
 public struct DCSettingView: View {
-    
+
     private let setting: any DCSettable
-    
+
     /// Initializes a new `DCSettingView` instance with the specified setting.
     ///
     /// This initializer creates a new instance of `DCSettingView` with the specified setting. The setting must be an instance of `DCSettable`.
@@ -386,7 +386,7 @@ public struct DCSettingView: View {
     public init(_ setting: any DCSettable) {
         self.setting = setting
     }
-    
+
     public var body: some View {
         if let concreteSetting = setting as? DCSetting<Bool> {
             DCBoolSettingView(setting: concreteSetting)

--- a/Sources/DCSettings/Views/DCSettingView.swift
+++ b/Sources/DCSettings/Views/DCSettingView.swift
@@ -73,15 +73,15 @@ struct DCIntSettingView: View {
     @ObservedObject var setting: DCSetting<Int>
     
     var body: some View {
-        if let options = setting.configuation?.options {
+        if let options = setting.configuration?.options {
             DCOptionPickerView(key: setting.key, label: setting.displayLabel, options: options, value: $setting.value)
         }
-        else if let bounds = setting.configuation?.bounds {
+        else if let bounds = setting.configuration?.bounds {
             DCSliderView(key: setting.key, label: setting.displayLabel, value: Binding(get: {
                 Double(setting.value)
             }, set: { newValue in
                 setting.value = Int(newValue)
-            }), bounds: DCValueBounds(lowerBound: Double(bounds.lowerBound), upperBound: Double(bounds.upperBound)), step: setting.configuation?.step.map { Double($0) }, specifier: "%.0f")
+            }), bounds: DCValueBounds(lowerBound: Double(bounds.lowerBound), upperBound: Double(bounds.upperBound)), step: setting.configuration?.step.map { Double($0) }, specifier: "%.0f")
         }
         else {
             HStack {
@@ -130,11 +130,11 @@ struct DCDoubleSettingView: View {
     @ObservedObject var setting: DCSetting<Double>
     
     var body: some View {
-        if let options = setting.configuation?.options {
+        if let options = setting.configuration?.options {
             DCOptionPickerView(key: setting.key, label: setting.displayLabel, options: options, value: $setting.value)
         }
         else {
-            DCSliderView(key: setting.key, label: setting.displayLabel, value: $setting.value, bounds: setting.configuation?.bounds, step: setting.configuation?.step, specifier: "%.2f")
+            DCSliderView(key: setting.key, label: setting.displayLabel, value: $setting.value, bounds: setting.configuration?.bounds, step: setting.configuration?.step, specifier: "%.2f")
         }
     }
 }
@@ -145,7 +145,7 @@ struct DCStringSettingView: View {
     @ObservedObject var setting: DCSetting<String>
     
     var body: some View {
-        if let options = setting.configuation?.options {
+        if let options = setting.configuration?.options {
             DCOptionPickerView(key: setting.key, label: setting.displayLabel, options: options, value: $setting.value)
         }
         else {
@@ -170,7 +170,7 @@ struct DCDateSettingView: View {
             // TODO: watchOS implementation
             Text(setting.displayLabel)
         #else
-            if let bounds = setting.configuation?.bounds {
+            if let bounds = setting.configuration?.bounds {
                 DatePicker(selection: $setting.value, in: Self.datePickerRange(for: bounds), displayedComponents: .date) {
                     Text(setting.displayLabel)
                 }

--- a/Sources/DCSettings/Views/DCSettingView.swift
+++ b/Sources/DCSettings/Views/DCSettingView.swift
@@ -374,7 +374,7 @@ struct DCMenuPickerView<ValueType>: View where ValueType: Equatable & Hashable {
 /// If no specific view is available for the value type, the view will be empty.
 ///
 /// Supported types are: `Bool`, `Int`,  `Double`, `String`, `Date` and `Color`.
-public struct DCSettingView: View {
+@MainActor public struct DCSettingView: View {
 
     private let setting: any DCSettable
 

--- a/Sources/DCSettings/Views/DCSettingView.swift
+++ b/Sources/DCSettings/Views/DCSettingView.swift
@@ -24,7 +24,6 @@ enum DCOptionControlStyle: Equatable {
 
 extension DCSettingOption {
     
-    @available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
     public func labelView() -> some View {
         return HStack {
             if let string = label {
@@ -52,7 +51,6 @@ extension DCSettingOption {
     }
 }
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 struct DCBoolSettingView: View {
     @Environment(\.isEnabled) var isEnabled
     
@@ -69,7 +67,6 @@ struct DCBoolSettingView: View {
     }
 }
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 struct DCIntSettingView: View {
     @Environment(\.isEnabled) var isEnabled
     
@@ -153,7 +150,6 @@ struct DCIntSettingView: View {
     }
 }
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 struct DCDoubleSettingView: View {
     @Environment(\.isEnabled) var isEnabled
     
@@ -193,7 +189,6 @@ struct DCDoubleSettingView: View {
     }
 }
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 struct DCStringSettingView: View {
     @Environment(\.isEnabled) var isEnabled
     
@@ -235,7 +230,6 @@ struct DCStringSettingView: View {
     }
 }
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 struct DCDateSettingView: View {
     @Environment(\.isEnabled) var isEnabled
     
@@ -264,7 +258,6 @@ struct DCDateSettingView: View {
     }
 }
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 struct DCColorSettingView: View {
     @Environment(\.isEnabled) var isEnabled
     
@@ -282,7 +275,6 @@ struct DCColorSettingView: View {
     }
 }
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 struct DCSliderView: View {
     @Environment(\.isEnabled) var isEnabled
     
@@ -346,7 +338,6 @@ struct DCSliderView: View {
     }
 }
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 struct DCMenuPickerView<ValueType>: View where ValueType: Equatable & Hashable {
     @Environment(\.isEnabled) var isEnabled
     
@@ -416,7 +407,6 @@ struct DCMenuPickerView<ValueType>: View where ValueType: Equatable & Hashable {
 /// If no specific view is available for the value type, the view will be empty.
 ///
 /// Supported types are: `Bool`, `Int`,  `Double`, `String`, `Date` and `Color`.
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 public struct DCSettingView: View {
     
     private let setting: any DCSettable
@@ -452,7 +442,6 @@ public struct DCSettingView: View {
     }
 }
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 struct DCSettingView_Previews: PreviewProvider {
 
     static var previews: some View {

--- a/Sources/DCSettings/Views/DCSettingView.swift
+++ b/Sources/DCSettings/Views/DCSettingView.swift
@@ -74,31 +74,7 @@ struct DCIntSettingView: View {
     
     var body: some View {
         if let options = setting.configuation?.options {
-            if DCOptionControlStyle(optionCount: options.count) == .menuPicker {
-                DCMenuPickerView(key: setting.key, label: setting.displayLabel, options: options, value: $setting.value)
-            }
-            else {
-                HStack {
-                    Text(setting.displayLabel)
-                    Spacer(minLength: 16.0)
-                    Picker(setting.displayLabel, selection: $setting.value) {
-                        ForEach(options, id: \.value) { option in
-                            option.labelView()
-                                .tag(option.value)
-                        }
-                    }
-                    .labelsHidden()
-                    .accessibilityIdentifier(setting.key)
-                    #if os(macOS)
-                        .pickerStyle(RadioGroupPickerStyle())
-                        .horizontalRadioGroupLayout()
-                    #elseif !os(watchOS)
-                        .pickerStyle(SegmentedPickerStyle())
-                        .frame(maxWidth: 140.0)
-                    #endif
-                }
-                .foregroundColor(isEnabled ? .primary : .secondary)
-            }
+            DCOptionPickerView(key: setting.key, label: setting.displayLabel, options: options, value: $setting.value)
         }
         else if let bounds = setting.configuation?.bounds {
             DCSliderView(key: setting.key, label: setting.displayLabel, value: Binding(get: {
@@ -151,37 +127,11 @@ struct DCIntSettingView: View {
 }
 
 struct DCDoubleSettingView: View {
-    @Environment(\.isEnabled) var isEnabled
-    
     @ObservedObject var setting: DCSetting<Double>
     
     var body: some View {
         if let options = setting.configuation?.options {
-            if DCOptionControlStyle(optionCount: options.count) == .menuPicker {
-                DCMenuPickerView(key: setting.key, label: setting.displayLabel, options: options, value: $setting.value)
-            }
-            else {
-                HStack {
-                    Text(setting.displayLabel)
-                    Spacer(minLength: 16.0)
-                    Picker(setting.displayLabel, selection: $setting.value) {
-                        ForEach(options, id: \.value) { option in
-                            option.labelView()
-                                .tag(option.value)
-                        }
-                    }
-                    .labelsHidden()
-                    .accessibilityIdentifier(setting.key)
-                    #if os(macOS)
-                        .pickerStyle(RadioGroupPickerStyle())
-                        .horizontalRadioGroupLayout()
-                    #elseif !os(watchOS)
-                        .pickerStyle(SegmentedPickerStyle())
-                        .frame(maxWidth: 140.0)
-                    #endif
-                }
-                .foregroundColor(isEnabled ? .primary : .secondary)
-            }
+            DCOptionPickerView(key: setting.key, label: setting.displayLabel, options: options, value: $setting.value)
         }
         else {
             DCSliderView(key: setting.key, label: setting.displayLabel, value: $setting.value, bounds: setting.configuation?.bounds, step: setting.configuation?.step, specifier: "%.2f")
@@ -196,31 +146,7 @@ struct DCStringSettingView: View {
     
     var body: some View {
         if let options = setting.configuation?.options {
-            if DCOptionControlStyle(optionCount: options.count) == .menuPicker {
-                DCMenuPickerView(key: setting.key, label: setting.displayLabel, options: options, value: $setting.value)
-            }
-            else {
-                HStack {
-                    Text(setting.displayLabel)
-                    Spacer(minLength: 16.0)
-                    Picker(setting.displayLabel, selection: $setting.value) {
-                        ForEach(options, id: \.value) { option in
-                            option.labelView()
-                                .tag(option.value)
-                        }
-                    }
-                    .labelsHidden()
-                    .accessibilityIdentifier(setting.key)
-                    #if os(macOS)
-                        .pickerStyle(RadioGroupPickerStyle())
-                        .horizontalRadioGroupLayout()
-                    #elseif os(iOS)
-                        .pickerStyle(SegmentedPickerStyle())
-                        .frame(maxWidth: 140.0)
-                    #endif
-                }
-                .foregroundColor(isEnabled ? .primary : .secondary)
-            }
+            DCOptionPickerView(key: setting.key, label: setting.displayLabel, options: options, value: $setting.value)
         }
         else {
             TextField(setting.displayLabel, text: $setting.value)
@@ -339,6 +265,43 @@ struct DCSliderView: View {
             }
         }
         .foregroundColor(isEnabled ? .primary : .secondary)
+    }
+}
+
+struct DCOptionPickerView<ValueType>: View where ValueType: Equatable & Hashable {
+    @Environment(\.isEnabled) var isEnabled
+    
+    let key: String
+    let label: String
+    let options: [DCSettingOption<ValueType>]
+    @Binding var value: ValueType
+    
+    var body: some View {
+        if DCOptionControlStyle(optionCount: options.count) == .menuPicker {
+            DCMenuPickerView(key: key, label: label, options: options, value: $value)
+        }
+        else {
+            HStack {
+                Text(label)
+                Spacer(minLength: 16.0)
+                Picker(label, selection: $value) {
+                    ForEach(options, id: \.value) { option in
+                        option.labelView()
+                            .tag(option.value)
+                    }
+                }
+                .labelsHidden()
+                .accessibilityIdentifier(key)
+                #if os(macOS)
+                    .pickerStyle(RadioGroupPickerStyle())
+                    .horizontalRadioGroupLayout()
+                #elseif !os(watchOS)
+                    .pickerStyle(SegmentedPickerStyle())
+                    .frame(maxWidth: 140.0)
+                #endif
+            }
+            .foregroundColor(isEnabled ? .primary : .secondary)
+        }
     }
 }
 

--- a/Sources/DCSettings/Views/DCSettingView.swift
+++ b/Sources/DCSettings/Views/DCSettingView.swift
@@ -13,6 +13,15 @@ extension DCSetting {
     }
 }
 
+enum DCOptionControlStyle: Equatable {
+    case picker
+    case menuPicker
+    
+    init(optionCount: Int) {
+        self = optionCount > 2 ? .menuPicker : .picker
+    }
+}
+
 extension DCSettingOption {
     
     @available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
@@ -68,7 +77,7 @@ struct DCIntSettingView: View {
     
     var body: some View {
         if let options = setting.configuation?.options {
-            if options.count > 2 {
+            if DCOptionControlStyle(optionCount: options.count) == .menuPicker {
                 DCMenuPickerView(key: setting.key, label: setting.displayLabel, options: options, value: $setting.value)
             }
             else {
@@ -99,7 +108,7 @@ struct DCIntSettingView: View {
                 Double(setting.value)
             }, set: { newValue in
                 setting.value = Int(newValue)
-            }), bounds: DCValueBounds(lowerBound: Double(bounds.lowerBound), upperBound: Double(bounds.upperBound)), step: Double(setting.configuation?.step ?? 0), specifier: "%.0f")
+            }), bounds: DCValueBounds(lowerBound: Double(bounds.lowerBound), upperBound: Double(bounds.upperBound)), step: setting.configuation?.step.map { Double($0) }, specifier: "%.0f")
         }
         else {
             HStack {
@@ -108,9 +117,36 @@ struct DCIntSettingView: View {
                 Spacer()
                 Text(String(setting.value))
                     .padding(.trailing, 8.0)
-                Stepper(setting.displayLabel, value: $setting.value)
-                    .labelsHidden()
-                    .accessibilityIdentifier(setting.key)
+                #if os(watchOS)
+                    if #available(watchOS 9.0, *) {
+                        Stepper(setting.displayLabel, value: $setting.value)
+                            .labelsHidden()
+                            .accessibilityIdentifier(setting.key)
+                    }
+                    else {
+                        HStack(spacing: 8.0) {
+                            Button {
+                                setting.value -= 1
+                            } label: {
+                                Image(systemName: "minus")
+                            }
+                            .accessibilityLabel("Decrease \(setting.displayLabel)")
+                            .accessibilityIdentifier("\(setting.key).decrement")
+                            
+                            Button {
+                                setting.value += 1
+                            } label: {
+                                Image(systemName: "plus")
+                            }
+                            .accessibilityLabel("Increase \(setting.displayLabel)")
+                            .accessibilityIdentifier("\(setting.key).increment")
+                        }
+                    }
+                #else
+                    Stepper(setting.displayLabel, value: $setting.value)
+                        .labelsHidden()
+                        .accessibilityIdentifier(setting.key)
+                #endif
             }
             .foregroundColor(isEnabled ? .primary : .secondary)
         }
@@ -119,11 +155,37 @@ struct DCIntSettingView: View {
 
 @available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 struct DCDoubleSettingView: View {
+    @Environment(\.isEnabled) var isEnabled
+    
     @ObservedObject var setting: DCSetting<Double>
     
     var body: some View {
-        if let options = setting.configuation?.options, options.count > 2 {
-            DCMenuPickerView(key: setting.key, label: setting.displayLabel, options: options, value: $setting.value)
+        if let options = setting.configuation?.options {
+            if DCOptionControlStyle(optionCount: options.count) == .menuPicker {
+                DCMenuPickerView(key: setting.key, label: setting.displayLabel, options: options, value: $setting.value)
+            }
+            else {
+                HStack {
+                    Text(setting.displayLabel)
+                    Spacer(minLength: 16.0)
+                    Picker(setting.displayLabel, selection: $setting.value) {
+                        ForEach(options, id: \.value) { option in
+                            option.labelView()
+                                .tag(option.value)
+                        }
+                    }
+                    .labelsHidden()
+                    .accessibilityIdentifier(setting.key)
+                    #if os(macOS)
+                        .pickerStyle(RadioGroupPickerStyle())
+                        .horizontalRadioGroupLayout()
+                    #elseif !os(watchOS)
+                        .pickerStyle(SegmentedPickerStyle())
+                        .frame(maxWidth: 140.0)
+                    #endif
+                }
+                .foregroundColor(isEnabled ? .primary : .secondary)
+            }
         }
         else {
             DCSliderView(key: setting.key, label: setting.displayLabel, value: $setting.value, bounds: setting.configuation?.bounds, step: setting.configuation?.step, specifier: "%.2f")
@@ -139,7 +201,7 @@ struct DCStringSettingView: View {
     
     var body: some View {
         if let options = setting.configuation?.options {
-            if options.count > 2 {
+            if DCOptionControlStyle(optionCount: options.count) == .menuPicker {
                 DCMenuPickerView(key: setting.key, label: setting.displayLabel, options: options, value: $setting.value)
             }
             else {
@@ -185,7 +247,7 @@ struct DCDateSettingView: View {
             Text(setting.displayLabel)
         #else
             if let bounds = setting.configuation?.bounds {
-                DatePicker(selection: $setting.value, in: bounds.upperBound...bounds.upperBound, displayedComponents: .date) {
+                DatePicker(selection: $setting.value, in: bounds.lowerBound...bounds.upperBound, displayedComponents: .date) {
                     Text(setting.displayLabel)
                 }
                 .foregroundColor(isEnabled ? .primary : .secondary)

--- a/Sources/DCSettings/Views/DCSettingView.swift
+++ b/Sources/DCSettings/Views/DCSettingView.swift
@@ -235,13 +235,17 @@ struct DCDateSettingView: View {
     
     @ObservedObject var setting: DCSetting<Date>
     
+    static func datePickerRange(for bounds: DCValueBounds<Date>) -> ClosedRange<Date> {
+        return bounds.lowerBound...bounds.upperBound
+    }
+    
     var body: some View {
         #if os(watchOS)
             // TODO: watchOS implementation
             Text(setting.displayLabel)
         #else
             if let bounds = setting.configuation?.bounds {
-                DatePicker(selection: $setting.value, in: bounds.lowerBound...bounds.upperBound, displayedComponents: .date) {
+                DatePicker(selection: $setting.value, in: Self.datePickerRange(for: bounds), displayedComponents: .date) {
                     Text(setting.displayLabel)
                 }
                 .foregroundColor(isEnabled ? .primary : .secondary)

--- a/Sources/DCSettings/Views/DCSettingView.swift
+++ b/Sources/DCSettings/Views/DCSettingView.swift
@@ -24,7 +24,7 @@ enum DCOptionControlStyle: Equatable {
 
 extension DCSettingOption {
 
-    public func labelView() -> some View {
+    func labelView() -> some View {
         return HStack {
             if let string = label {
                 if let imageName = image {
@@ -167,8 +167,9 @@ struct DCDateSettingView: View {
 
     var body: some View {
         #if os(watchOS)
-            // TODO: watchOS implementation
             Text(setting.displayLabel)
+                .foregroundColor(isEnabled ? .primary : .secondary)
+                .accessibilityIdentifier(setting.key)
         #else
             if let bounds = setting.configuration?.bounds {
                 DatePicker(selection: $setting.value, in: Self.datePickerRange(for: bounds), displayedComponents: .date) {
@@ -195,8 +196,9 @@ struct DCColorSettingView: View {
 
     var body: some View {
         #if os(watchOS)
-            // TODO: watchOS implementation
             Text(setting.displayLabel)
+                .foregroundColor(isEnabled ? .primary : .secondary)
+                .accessibilityIdentifier(setting.key)
         #else
             ColorPicker(setting.displayLabel, selection: $setting.value)
             .foregroundColor(isEnabled ? .primary : .secondary)

--- a/Sources/DCSettings/Views/DCSettingViewProviding.swift
+++ b/Sources/DCSettings/Views/DCSettingViewProviding.swift
@@ -11,7 +11,7 @@ import SwiftUI
 /// The `DCSettingViewProviding` protocol defines the requirements for a type that provides custom views for settings.
 /// The protocol includes a `content` method that takes a `DCSettable` instance as an argument
 /// and returns an optional view representing the user interface for changing the setting.
-public protocol DCSettingViewProviding {
+@MainActor public protocol DCSettingViewProviding {
 
     /// The type of view returned by the `content` method.
     associatedtype Content: View

--- a/Sources/DCSettings/Views/DCSettingViewProviding.swift
+++ b/Sources/DCSettings/Views/DCSettingViewProviding.swift
@@ -12,10 +12,10 @@ import SwiftUI
 /// The protocol includes a `content` method that takes a `DCSettable` instance as an argument
 /// and returns an optional view representing the user interface for changing the setting.
 public protocol DCSettingViewProviding {
-    
+
     /// The type of view returned by the `content` method.
     associatedtype Content: View
-    
+
     /// Returns a view representing the user interface for changing the specified setting.
     ///
     /// This method takes a `DCSettable` instance as an argument and returns an optional view representing the user interface for managing the setting.
@@ -31,10 +31,10 @@ public protocol DCSettingViewProviding {
 /// `DCDefaultViewProvider` is a concrete implementation of the `DCSettingViewProviding` protocol that provides no custom views for settings.
 /// This type can be used as a placeholder when no custom views are needed.
 public struct DCDefaultViewProvider: DCSettingViewProviding {
-    
+
     /// Creates a new `DCDefaultViewProvider` instance.
     public init() {}
-    
+
     /// Returns a view representing the user interface for changing the specified setting.
     ///
     /// This default implementation of the `content` method always returns `nil`, indicating that no custom view is available for the specified setting.

--- a/Sources/DCSettings/Views/DCSettingsView.swift
+++ b/Sources/DCSettings/Views/DCSettingsView.swift
@@ -14,7 +14,6 @@ import SwiftUI
 /// The view uses a `DCSettingViewProviding` instance to provide custom views for individual settings.
 /// If no custom view is available for a specific setting, a default view will be used if the setting's value is a supported type.
 /// Supported types as standard are: `Bool`, `Int`, `Double`, `String`, `Date` and `Color`.
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 public struct DCSettingsView<Provider: DCSettingViewProviding, S: ListStyle>: View {
     
     /// An enumeration that defines the available filters for the settings view.
@@ -80,7 +79,6 @@ public struct DCSettingsView<Provider: DCSettingViewProviding, S: ListStyle>: Vi
     }
 }
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 extension DCSettingsView where Provider == DCDefaultViewProvider {
     
     /// Initializes a new settings view with the default content provider and the specified list style.
@@ -90,7 +88,6 @@ extension DCSettingsView where Provider == DCDefaultViewProvider {
 }
 
 #if os(macOS)
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 extension DCSettingsView where S == SidebarListStyle {
     
     /// Initializes a new settings view with the platform default list style.
@@ -99,7 +96,6 @@ extension DCSettingsView where S == SidebarListStyle {
     }
 }
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 extension DCSettingsView where Provider == DCDefaultViewProvider, S == SidebarListStyle {
     
     /// Initializes a new settings view with the default content provider and platform default list style.
@@ -108,7 +104,6 @@ extension DCSettingsView where Provider == DCDefaultViewProvider, S == SidebarLi
     }
 }
 #elseif os(watchOS)
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 extension DCSettingsView where S == DefaultListStyle {
     
     /// Initializes a new settings view with the platform default list style.
@@ -117,7 +112,6 @@ extension DCSettingsView where S == DefaultListStyle {
     }
 }
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 extension DCSettingsView where Provider == DCDefaultViewProvider, S == DefaultListStyle {
     
     /// Initializes a new settings view with the default content provider and platform default list style.
@@ -126,7 +120,6 @@ extension DCSettingsView where Provider == DCDefaultViewProvider, S == DefaultLi
     }
 }
 #else
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 extension DCSettingsView where S == InsetGroupedListStyle {
     
     /// Initializes a new settings view with the platform default list style.
@@ -135,7 +128,6 @@ extension DCSettingsView where S == InsetGroupedListStyle {
     }
 }
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 extension DCSettingsView where Provider == DCDefaultViewProvider, S == InsetGroupedListStyle {
     
     /// Initializes a new settings view with the default content provider and platform default list style.
@@ -145,7 +137,6 @@ extension DCSettingsView where Provider == DCDefaultViewProvider, S == InsetGrou
 }
 #endif
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 struct DCSettingsView_Previews: PreviewProvider {
 
     static var previews: some View {

--- a/Sources/DCSettings/Views/DCSettingsView.swift
+++ b/Sources/DCSettings/Views/DCSettingsView.swift
@@ -13,7 +13,7 @@ import SwiftUI
 ///
 /// The view uses a `DCSettingViewProviding` instance to provide custom views for individual settings.
 /// If no custom view is available for a specific setting, a default view will be used if the setting's value is a supported type.
-/// Supported types as standard are: `Bool`, `Int`, `Double`, `String`, `Date` and `Color`.
+/// Supported types are: `Bool`, `Int`, `Double`, `String`, `Date` and `Color`.
 @MainActor public struct DCSettingsView<Provider: DCSettingViewProviding, S: ListStyle>: View {
 
     /// An enumeration that defines the available filters for the settings view.

--- a/Sources/DCSettings/Views/DCSettingsView.swift
+++ b/Sources/DCSettings/Views/DCSettingsView.swift
@@ -41,7 +41,7 @@ public struct DCSettingsView<Provider: DCSettingViewProviding, S: ListStyle>: Vi
     /// Initializes a new `DCSettingsView` instance with the specified settings manager, filter, and content provider.
     ///
     /// This initializer creates a new instance of `DCSettingsView` with the specified settings manager, filter, and content provider.
-    /// The settings manager is required, while the filter is optional.
+    /// The settings manager defaults to the `.shared` singleton instance, while the filter is optional.
     ///
     /// - Parameters:
     ///   - settingsManager: A `DCSettingsManager` instance used to manage the settings.

--- a/Sources/DCSettings/Views/DCSettingsView.swift
+++ b/Sources/DCSettings/Views/DCSettingsView.swift
@@ -14,7 +14,7 @@ import SwiftUI
 /// The view uses a `DCSettingViewProviding` instance to provide custom views for individual settings.
 /// If no custom view is available for a specific setting, a default view will be used if the setting's value is a supported type.
 /// Supported types as standard are: `Bool`, `Int`, `Double`, `String`, `Date` and `Color`.
-public struct DCSettingsView<Provider: DCSettingViewProviding, S: ListStyle>: View {
+@MainActor public struct DCSettingsView<Provider: DCSettingViewProviding, S: ListStyle>: View {
 
     /// An enumeration that defines the available filters for the settings view.
     public enum Filter: Equatable {

--- a/Sources/DCSettings/Views/DCSettingsView.swift
+++ b/Sources/DCSettings/Views/DCSettingsView.swift
@@ -42,30 +42,20 @@ public struct DCSettingsView<Provider: DCSettingViewProviding, S: ListStyle>: Vi
     /// Initializes a new `DCSettingsView` instance with the specified settings manager, filter, and content provider.
     ///
     /// This initializer creates a new instance of `DCSettingsView` with the specified settings manager, filter, and content provider.
-    /// The settings manager is required, while the filter and content provider are optional.
+    /// The settings manager is required, while the filter is optional.
     ///
     /// - Parameters:
     ///   - settingsManager: A `DCSettingsManager` instance used to manage the settings.
     ///   The default value is the `.shared` singleton instance.
     ///   - filter: A `Filter` value used to filter the displayed settings. The default value is `nil`.
     ///   - contentProvider: A `DCSettingViewProviding` instance used to provide custom views for individual settings.
-    ///   The default value is an instance of `DCDefaultViewProvider`.
-    ///   - listStyle: A `ListStyle` value used to set the style of the list. The default value is platform-dependent.
-    #if os(macOS)
-        public init(settingsManager: DCSettingsManager = .shared, filter: Filter? = nil, contentProvider: Provider? = DCDefaultViewProvider(), listStyle: S = SidebarListStyle()) {
-            self.settingsManager = settingsManager
-            self.filter = filter
-            self.contentProvider = contentProvider
-            self.listStyle = listStyle
-        }
-    #else
-        public init(settingsManager: DCSettingsManager = .shared, filter: Filter? = nil, contentProvider: Provider? = DCDefaultViewProvider(), listStyle: S = InsetGroupedListStyle()) {
-            self.settingsManager = settingsManager
-            self.filter = filter
-            self.contentProvider = contentProvider
-            self.listStyle = listStyle
-        }
-    #endif
+    ///   - listStyle: A `ListStyle` value used to set the style of the list.
+    public init(settingsManager: DCSettingsManager = .shared, filter: Filter? = nil, contentProvider: Provider?, listStyle: S) {
+        self.settingsManager = settingsManager
+        self.filter = filter
+        self.contentProvider = contentProvider
+        self.listStyle = listStyle
+    }
     
     public var body: some View {
         List(settingsManager.groups) { group in
@@ -89,6 +79,71 @@ public struct DCSettingsView<Provider: DCSettingViewProviding, S: ListStyle>: Vi
         .listStyle(listStyle)
     }
 }
+
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
+extension DCSettingsView where Provider == DCDefaultViewProvider {
+    
+    /// Initializes a new settings view with the default content provider and the specified list style.
+    public init(settingsManager: DCSettingsManager = .shared, filter: Filter? = nil, listStyle: S) {
+        self.init(settingsManager: settingsManager, filter: filter, contentProvider: DCDefaultViewProvider(), listStyle: listStyle)
+    }
+}
+
+#if os(macOS)
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
+extension DCSettingsView where S == SidebarListStyle {
+    
+    /// Initializes a new settings view with the platform default list style.
+    public init(settingsManager: DCSettingsManager = .shared, filter: Filter? = nil, contentProvider: Provider?) {
+        self.init(settingsManager: settingsManager, filter: filter, contentProvider: contentProvider, listStyle: SidebarListStyle())
+    }
+}
+
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
+extension DCSettingsView where Provider == DCDefaultViewProvider, S == SidebarListStyle {
+    
+    /// Initializes a new settings view with the default content provider and platform default list style.
+    public init(settingsManager: DCSettingsManager = .shared, filter: Filter? = nil) {
+        self.init(settingsManager: settingsManager, filter: filter, contentProvider: DCDefaultViewProvider(), listStyle: SidebarListStyle())
+    }
+}
+#elseif os(watchOS)
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
+extension DCSettingsView where S == DefaultListStyle {
+    
+    /// Initializes a new settings view with the platform default list style.
+    public init(settingsManager: DCSettingsManager = .shared, filter: Filter? = nil, contentProvider: Provider?) {
+        self.init(settingsManager: settingsManager, filter: filter, contentProvider: contentProvider, listStyle: DefaultListStyle())
+    }
+}
+
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
+extension DCSettingsView where Provider == DCDefaultViewProvider, S == DefaultListStyle {
+    
+    /// Initializes a new settings view with the default content provider and platform default list style.
+    public init(settingsManager: DCSettingsManager = .shared, filter: Filter? = nil) {
+        self.init(settingsManager: settingsManager, filter: filter, contentProvider: DCDefaultViewProvider(), listStyle: DefaultListStyle())
+    }
+}
+#else
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
+extension DCSettingsView where S == InsetGroupedListStyle {
+    
+    /// Initializes a new settings view with the platform default list style.
+    public init(settingsManager: DCSettingsManager = .shared, filter: Filter? = nil, contentProvider: Provider?) {
+        self.init(settingsManager: settingsManager, filter: filter, contentProvider: contentProvider, listStyle: InsetGroupedListStyle())
+    }
+}
+
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
+extension DCSettingsView where Provider == DCDefaultViewProvider, S == InsetGroupedListStyle {
+    
+    /// Initializes a new settings view with the default content provider and platform default list style.
+    public init(settingsManager: DCSettingsManager = .shared, filter: Filter? = nil) {
+        self.init(settingsManager: settingsManager, filter: filter, contentProvider: DCDefaultViewProvider(), listStyle: InsetGroupedListStyle())
+    }
+}
+#endif
 
 @available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 8.0, visionOS 1.0, *)
 struct DCSettingsView_Previews: PreviewProvider {

--- a/Sources/DCSettings/Views/DCSettingsView.swift
+++ b/Sources/DCSettings/Views/DCSettingsView.swift
@@ -15,22 +15,22 @@ import SwiftUI
 /// If no custom view is available for a specific setting, a default view will be used if the setting's value is a supported type.
 /// Supported types as standard are: `Bool`, `Int`, `Double`, `String`, `Date` and `Color`.
 public struct DCSettingsView<Provider: DCSettingViewProviding, S: ListStyle>: View {
-    
+
     /// An enumeration that defines the available filters for the settings view.
     public enum Filter: Equatable {
-        
+
         /// A filter that includes only settings with labels.
         case labelled
-        
+
         /// A filter that excludes settings with the specified keys.
         case excludeKeys([String])
     }
-    
+
     private let settingsManager: DCSettingsManager
     private let filter: Filter?
     private let contentProvider: Provider?
     private let listStyle: S
-    
+
     private var hiddenKeys: [String] {
         if case .excludeKeys(let keys) = filter {
             return keys
@@ -55,7 +55,7 @@ public struct DCSettingsView<Provider: DCSettingViewProviding, S: ListStyle>: Vi
         self.contentProvider = contentProvider
         self.listStyle = listStyle
     }
-    
+
     public var body: some View {
         List(settingsManager.groups) { group in
             if !hiddenKeys.contains(group.key.keyValue) {
@@ -80,7 +80,7 @@ public struct DCSettingsView<Provider: DCSettingViewProviding, S: ListStyle>: Vi
 }
 
 extension DCSettingsView where Provider == DCDefaultViewProvider {
-    
+
     /// Initializes a new settings view with the default content provider and the specified list style.
     public init(settingsManager: DCSettingsManager = .shared, filter: Filter? = nil, listStyle: S) {
         self.init(settingsManager: settingsManager, filter: filter, contentProvider: DCDefaultViewProvider(), listStyle: listStyle)
@@ -89,7 +89,7 @@ extension DCSettingsView where Provider == DCDefaultViewProvider {
 
 #if os(macOS)
 extension DCSettingsView where S == SidebarListStyle {
-    
+
     /// Initializes a new settings view with the platform default list style.
     public init(settingsManager: DCSettingsManager = .shared, filter: Filter? = nil, contentProvider: Provider?) {
         self.init(settingsManager: settingsManager, filter: filter, contentProvider: contentProvider, listStyle: SidebarListStyle())
@@ -97,7 +97,7 @@ extension DCSettingsView where S == SidebarListStyle {
 }
 
 extension DCSettingsView where Provider == DCDefaultViewProvider, S == SidebarListStyle {
-    
+
     /// Initializes a new settings view with the default content provider and platform default list style.
     public init(settingsManager: DCSettingsManager = .shared, filter: Filter? = nil) {
         self.init(settingsManager: settingsManager, filter: filter, contentProvider: DCDefaultViewProvider(), listStyle: SidebarListStyle())
@@ -105,7 +105,7 @@ extension DCSettingsView where Provider == DCDefaultViewProvider, S == SidebarLi
 }
 #elseif os(watchOS)
 extension DCSettingsView where S == DefaultListStyle {
-    
+
     /// Initializes a new settings view with the platform default list style.
     public init(settingsManager: DCSettingsManager = .shared, filter: Filter? = nil, contentProvider: Provider?) {
         self.init(settingsManager: settingsManager, filter: filter, contentProvider: contentProvider, listStyle: DefaultListStyle())
@@ -113,7 +113,7 @@ extension DCSettingsView where S == DefaultListStyle {
 }
 
 extension DCSettingsView where Provider == DCDefaultViewProvider, S == DefaultListStyle {
-    
+
     /// Initializes a new settings view with the default content provider and platform default list style.
     public init(settingsManager: DCSettingsManager = .shared, filter: Filter? = nil) {
         self.init(settingsManager: settingsManager, filter: filter, contentProvider: DCDefaultViewProvider(), listStyle: DefaultListStyle())
@@ -121,7 +121,7 @@ extension DCSettingsView where Provider == DCDefaultViewProvider, S == DefaultLi
 }
 #else
 extension DCSettingsView where S == InsetGroupedListStyle {
-    
+
     /// Initializes a new settings view with the platform default list style.
     public init(settingsManager: DCSettingsManager = .shared, filter: Filter? = nil, contentProvider: Provider?) {
         self.init(settingsManager: settingsManager, filter: filter, contentProvider: contentProvider, listStyle: InsetGroupedListStyle())
@@ -129,7 +129,7 @@ extension DCSettingsView where S == InsetGroupedListStyle {
 }
 
 extension DCSettingsView where Provider == DCDefaultViewProvider, S == InsetGroupedListStyle {
-    
+
     /// Initializes a new settings view with the default content provider and platform default list style.
     public init(settingsManager: DCSettingsManager = .shared, filter: Filter? = nil) {
         self.init(settingsManager: settingsManager, filter: filter, contentProvider: DCDefaultViewProvider(), listStyle: InsetGroupedListStyle())

--- a/Tests/DCSettingsTests/DCSettingConfigurationTests.swift
+++ b/Tests/DCSettingsTests/DCSettingConfigurationTests.swift
@@ -4,12 +4,12 @@
 //  MIT license, see LICENSE file for details
 //
 
-import XCTest
+import Testing
 @testable import DCSettings
 
-class DCSettingConfigurationTests: XCTestCase {
+@Suite struct DCSettingConfigurationTests {
 
-    func testInitWithOptions() {
+    @Test func initWithOptions() {
         let options = [
             DCSettingOption(value: "option1"),
             DCSettingOption(value: "option2"),
@@ -17,20 +17,20 @@ class DCSettingConfigurationTests: XCTestCase {
         ]
         let configuration = DCSettingConfiguration(options: options, bounds: nil, step: nil)
 
-        XCTAssertEqual(configuration.options?.count, 3)
-        XCTAssertEqual(configuration.options, options)
+        #expect(configuration.options?.count == 3)
+        #expect(configuration.options == options)
     }
 
-    func testInitWithBounds() {
+    @Test func initWithBounds() {
         let bounds = DCValueBounds(lowerBound: 0, upperBound: 10)
         let configuration = DCSettingConfiguration(options: nil, bounds: bounds, step: nil)
 
-        XCTAssertEqual(configuration.bounds, bounds)
+        #expect(configuration.bounds == bounds)
     }
 
-    func testInitWithStep() {
+    @Test func initWithStep() {
         let configuration = DCSettingConfiguration(options: nil, bounds: nil, step: 2)
 
-        XCTAssertEqual(configuration.step, 2)
+        #expect(configuration.step == 2)
     }
 }

--- a/Tests/DCSettingsTests/DCSettingConfigurationTests.swift
+++ b/Tests/DCSettingsTests/DCSettingConfigurationTests.swift
@@ -8,7 +8,7 @@ import XCTest
 @testable import DCSettings
 
 class DCSettingConfigurationTests: XCTestCase {
-    
+
     func testInitWithOptions() {
         let options = [
             DCSettingOption(value: "option1"),
@@ -16,21 +16,21 @@ class DCSettingConfigurationTests: XCTestCase {
             DCSettingOption(value: "option3")
         ]
         let configuration = DCSettingConfiguration(options: options, bounds: nil, step: nil)
-        
+
         XCTAssertEqual(configuration.options?.count, 3)
         XCTAssertEqual(configuration.options, options)
     }
-    
+
     func testInitWithBounds() {
         let bounds = DCValueBounds(lowerBound: 0, upperBound: 10)
         let configuration = DCSettingConfiguration(options: nil, bounds: bounds, step: nil)
-        
+
         XCTAssertEqual(configuration.bounds, bounds)
     }
-    
+
     func testInitWithStep() {
         let configuration = DCSettingConfiguration(options: nil, bounds: nil, step: 2)
-        
+
         XCTAssertEqual(configuration.step, 2)
     }
 }

--- a/Tests/DCSettingsTests/DCSettingGroupTests.swift
+++ b/Tests/DCSettingsTests/DCSettingGroupTests.swift
@@ -4,62 +4,65 @@
 //  MIT license, see LICENSE file for details
 //
 
-import XCTest
+import Testing
 @testable import DCSettings
 
-@MainActor class DCSettingGroupTests: XCTestCase {
+@Suite @MainActor struct DCSettingGroupTests {
 
-    private var store: DCSettingStore!
-    private var setting1: DCSetting<String>!
-    private var setting2: DCSetting<Int>!
-    private var group: DCSettingGroup!
+    private let store: DCSettingStore
+    private let setting1: DCSetting<String>
+    private let setting2: DCSetting<Int>
+    private let group: DCSettingGroup
 
-    override func setUp() async throws {
-        try await super.setUp()
-        store = .custom(backingStore: MockStore())
-        setting1 = DCSetting(key: "testKey1", defaultValue: "defaultValue1")
-        setting2 = DCSetting(key: "testKey2", defaultValue: 0)
-        group = DCSettingGroup(store: store) {
+    init() {
+        let store = DCSettingStore.custom(backingStore: MockStore())
+        let setting1 = DCSetting(key: "testKey1", defaultValue: "defaultValue1")
+        let setting2 = DCSetting(key: "testKey2", defaultValue: 0)
+
+        self.store = store
+        self.setting1 = setting1
+        self.setting2 = setting2
+        self.group = DCSettingGroup(store: store) {
             setting1
             setting2
         }
     }
 
-    func testSettings() {
-        XCTAssertEqual(group.settings.count, 2)
+    @Test func settings() {
+        #expect(group.settings.count == 2)
     }
 
-    func testKeyLabelAndID() {
+    @Test func keyLabelAndID() {
         let group = DCSettingGroup(key: "general", label: "General", store: store, settings: [setting1])
 
-        XCTAssertEqual(group.key, "general")
-        XCTAssertEqual(group.id, "general")
-        XCTAssertEqual(group.label, "General")
+        #expect(group.key == "general")
+        #expect(group.id == "general")
+        #expect(group.label == "General")
     }
 
-    func testLabelInitializerCreatesGroupWithSettings() {
+    @Test func labelInitializerCreatesGroupWithSettings() {
         let group = DCSettingGroup("General", store: store, settings: [setting1, setting2])
 
-        XCTAssertEqual(group.label, "General")
-        XCTAssertEqual(group.settings.count, 2)
+        #expect(group.label == "General")
+        #expect(group.settings.count == 2)
     }
 
-    func testStoreModifierReturnsCopyWithNewStore() {
+    @Test func storeModifierReturnsCopyWithNewStore() {
         let newStore = DCSettingStore.custom(backingStore: MockStore())
 
         let updatedGroup = group.store(newStore)
 
-        XCTAssertEqual(updatedGroup.key, group.key)
-        XCTAssertEqual(updatedGroup.label, group.label)
-        XCTAssertEqual(updatedGroup.settings.count, group.settings.count)
+        #expect(updatedGroup.key == group.key)
+        #expect(updatedGroup.label == group.label)
+        #expect(updatedGroup.settings.count == group.settings.count)
     }
 
-    func testGroupsBuilderBuildsGroups() {
+    @Test func groupsBuilderBuildsGroups() {
         let groups = DCSettingGroupsBuilder.buildBlock(
             DCSettingGroup("General", settings: [setting1]),
             DCSettingGroup("Appearance", settings: [setting2])
         )
 
-        XCTAssertEqual(groups.map(\.label), ["General", "Appearance"])
+        #expect(groups.map(\.label) == ["General", "Appearance"])
     }
 }

--- a/Tests/DCSettingsTests/DCSettingGroupTests.swift
+++ b/Tests/DCSettingsTests/DCSettingGroupTests.swift
@@ -7,15 +7,15 @@
 import XCTest
 @testable import DCSettings
 
-class DCSettingGroupTests: XCTestCase {
+@MainActor class DCSettingGroupTests: XCTestCase {
 
     private var store: DCSettingStore!
     private var setting1: DCSetting<String>!
     private var setting2: DCSetting<Int>!
     private var group: DCSettingGroup!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         store = .custom(backingStore: MockStore())
         setting1 = DCSetting(key: "testKey1", defaultValue: "defaultValue1")
         setting2 = DCSetting(key: "testKey2", defaultValue: 0)

--- a/Tests/DCSettingsTests/DCSettingGroupTests.swift
+++ b/Tests/DCSettingsTests/DCSettingGroupTests.swift
@@ -65,4 +65,80 @@ import Testing
 
         #expect(groups.map(\.label) == ["General", "Appearance"])
     }
+
+    @Test func settingsBuilderSupportsEmptyBody() {
+        let group = DCSettingGroup("Empty") {
+        }
+
+        #expect(group.settings.isEmpty)
+    }
+
+    @Test func settingsBuilderSupportsControlFlow() {
+        let includeSecondSetting = false
+        let loopedKeys = ["loop1", "loop2"]
+        let selectedKey = "switch"
+
+        let group = DCSettingGroup("Control Flow") {
+            setting1
+
+            if includeSecondSetting {
+                setting2
+            }
+            else {
+                DCSetting(key: "fallback", defaultValue: "fallback")
+            }
+
+            for key in loopedKeys {
+                DCSetting(key: key, defaultValue: key)
+            }
+
+            switch selectedKey {
+            case "switch":
+                DCSetting(key: "switch", defaultValue: "switch")
+            default:
+                DCSetting(key: "default", defaultValue: "default")
+            }
+        }
+
+        #expect(group.settings.map(\.key) == ["testKey1", "fallback", "loop1", "loop2", "switch"])
+    }
+
+    @Test func groupsBuilderSupportsControlFlow() {
+        let includeAppearance = false
+        let selectedGroup = "Labs"
+
+        let manager = DCSettingsManager()
+        manager.configure {
+            DCSettingGroup("General", settings: [setting1])
+
+            if includeAppearance {
+                DCSettingGroup("Appearance", settings: [setting2])
+            }
+            else {
+                DCSettingGroup("Fallback", settings: [])
+            }
+
+            for label in ["Advanced", "Debug"] {
+                DCSettingGroup(label, settings: [])
+            }
+
+            switch selectedGroup {
+            case "Labs":
+                DCSettingGroup("Labs", settings: [])
+            default:
+                DCSettingGroup("Other", settings: [])
+            }
+        }
+
+        #expect(manager.groups.map(\.label) == ["General", "Fallback", "Advanced", "Debug", "Labs"])
+    }
+
+    @Test func groupsBuilderSupportsEmptyBody() {
+        let manager = DCSettingsManager()
+
+        manager.configure {
+        }
+
+        #expect(manager.groups.isEmpty)
+    }
 }

--- a/Tests/DCSettingsTests/DCSettingGroupTests.swift
+++ b/Tests/DCSettingsTests/DCSettingGroupTests.swift
@@ -28,4 +28,38 @@ class DCSettingGroupTests: XCTestCase {
     func testSettings() {
         XCTAssertEqual(group.settings.count, 2)
     }
+    
+    func testKeyLabelAndID() {
+        let group = DCSettingGroup(key: "general", label: "General", store: store, settings: [setting1])
+        
+        XCTAssertEqual(group.key, "general")
+        XCTAssertEqual(group.id, "general")
+        XCTAssertEqual(group.label, "General")
+    }
+    
+    func testLabelInitializerCreatesGroupWithSettings() {
+        let group = DCSettingGroup("General", store: store, settings: [setting1, setting2])
+        
+        XCTAssertEqual(group.label, "General")
+        XCTAssertEqual(group.settings.count, 2)
+    }
+    
+    func testStoreModifierReturnsCopyWithNewStore() {
+        let newStore = DCSettingStore.custom(backingStore: MockStore())
+        
+        let updatedGroup = group.store(newStore)
+        
+        XCTAssertEqual(updatedGroup.key, group.key)
+        XCTAssertEqual(updatedGroup.label, group.label)
+        XCTAssertEqual(updatedGroup.settings.count, group.settings.count)
+    }
+    
+    func testGroupsBuilderBuildsGroups() {
+        let groups = DCSettingGroupsBuilder.buildBlock(
+            DCSettingGroup("General", settings: [setting1]),
+            DCSettingGroup("Appearance", settings: [setting2])
+        )
+        
+        XCTAssertEqual(groups.map(\.label), ["General", "Appearance"])
+    }
 }

--- a/Tests/DCSettingsTests/DCSettingGroupTests.swift
+++ b/Tests/DCSettingsTests/DCSettingGroupTests.swift
@@ -8,12 +8,12 @@ import XCTest
 @testable import DCSettings
 
 class DCSettingGroupTests: XCTestCase {
-    
+
     private var store: DCSettingStore!
     private var setting1: DCSetting<String>!
     private var setting2: DCSetting<Int>!
     private var group: DCSettingGroup!
-    
+
     override func setUp() {
         super.setUp()
         store = .custom(backingStore: MockStore())
@@ -24,42 +24,42 @@ class DCSettingGroupTests: XCTestCase {
             setting2
         }
     }
-    
+
     func testSettings() {
         XCTAssertEqual(group.settings.count, 2)
     }
-    
+
     func testKeyLabelAndID() {
         let group = DCSettingGroup(key: "general", label: "General", store: store, settings: [setting1])
-        
+
         XCTAssertEqual(group.key, "general")
         XCTAssertEqual(group.id, "general")
         XCTAssertEqual(group.label, "General")
     }
-    
+
     func testLabelInitializerCreatesGroupWithSettings() {
         let group = DCSettingGroup("General", store: store, settings: [setting1, setting2])
-        
+
         XCTAssertEqual(group.label, "General")
         XCTAssertEqual(group.settings.count, 2)
     }
-    
+
     func testStoreModifierReturnsCopyWithNewStore() {
         let newStore = DCSettingStore.custom(backingStore: MockStore())
-        
+
         let updatedGroup = group.store(newStore)
-        
+
         XCTAssertEqual(updatedGroup.key, group.key)
         XCTAssertEqual(updatedGroup.label, group.label)
         XCTAssertEqual(updatedGroup.settings.count, group.settings.count)
     }
-    
+
     func testGroupsBuilderBuildsGroups() {
         let groups = DCSettingGroupsBuilder.buildBlock(
             DCSettingGroup("General", settings: [setting1]),
             DCSettingGroup("Appearance", settings: [setting2])
         )
-        
+
         XCTAssertEqual(groups.map(\.label), ["General", "Appearance"])
     }
 }

--- a/Tests/DCSettingsTests/DCSettingOptionTests.swift
+++ b/Tests/DCSettingsTests/DCSettingOptionTests.swift
@@ -9,6 +9,23 @@ import XCTest
 
 final class DCSettingOptionTests: XCTestCase {
     
+    private enum TestOption: String, DCSettingOptionProviding {
+        case first
+        case second
+        
+        static var defaultCase: TestOption? {
+            return .second
+        }
+        
+        var label: String? {
+            return rawValue.sentenceFormatted
+        }
+        
+        var image: DCImageName? {
+            return .system(rawValue)
+        }
+    }
+    
     func testEquatable() {
         let option1 = DCSettingOption(value: "Value1", label: "Label1", image: "Image1")
         let option2 = DCSettingOption(value: "Value1", label: "Label1", image: "Image1")
@@ -41,5 +58,41 @@ final class DCSettingOptionTests: XCTestCase {
     func testDefaultOption() {
         let option = DCSettingOption(value: "Value", default: true)
         XCTAssertTrue(option.isDefault)
+    }
+    
+    func testDefaultModifierReturnsDefaultOption() {
+        let option = DCSettingOption(value: "Value", label: "Label").default()
+        
+        XCTAssertTrue(option.isDefault)
+        XCTAssertEqual(option.label, "Label")
+        XCTAssertEqual(option.value, "Value")
+    }
+    
+    func testImageOnlyInitializers() {
+        let customImageOption = DCSettingOption(value: "Value", image: "Image")
+        let systemImageOption = DCSettingOption(value: "Value", systemImage: "SystemImage")
+        
+        XCTAssertNil(customImageOption.label)
+        XCTAssertEqual(customImageOption.image, .custom("Image"))
+        XCTAssertNil(systemImageOption.label)
+        XCTAssertEqual(systemImageOption.image, .system("SystemImage"))
+    }
+    
+    func testDefaultOptionProvidingImplementations() {
+        XCTAssertNil(StringDefaultOption.defaultCase)
+        XCTAssertNil(StringDefaultOption.sample.label)
+        XCTAssertNil(StringDefaultOption.sample.image)
+    }
+    
+    func testOptionsProviderInitializerUsesProviderMetadata() {
+        let setting = DCSetting(key: "optionProvider", optionsProvider: TestOption.self)
+        
+        XCTAssertEqual(setting?.value, TestOption.second.rawValue)
+        XCTAssertEqual(setting?.configuation?.options?.first?.label, "First")
+        XCTAssertEqual(setting?.configuation?.options?.first?.image, .system("first"))
+    }
+    
+    private enum StringDefaultOption: String, DCSettingOptionProviding {
+        case sample
     }
 }

--- a/Tests/DCSettingsTests/DCSettingOptionTests.swift
+++ b/Tests/DCSettingsTests/DCSettingOptionTests.swift
@@ -92,6 +92,42 @@ import Testing
         #expect(setting.configuration?.options?.first?.image == .system("first"))
     }
 
+    @Test func optionsBuilderSupportsEmptyBody() {
+        let setting: DCSetting<String>? = DCSetting(key: "emptyOptions") {
+        }
+
+        #expect(setting == nil)
+    }
+
+    @Test func optionsBuilderSupportsControlFlow() throws {
+        let includeSecond = false
+        let selectedValue = "switch"
+        let setting = try #require(DCSetting(key: "controlFlowOptions") {
+            DCSettingOption(value: "first", label: "First")
+
+            if includeSecond {
+                DCSettingOption(value: "second", label: "Second").default()
+            }
+            else {
+                DCSettingOption(value: "fallback", label: "Fallback").default()
+            }
+
+            for value in ["third", "fourth"] {
+                DCSettingOption(value: value, label: value.sentenceFormatted)
+            }
+
+            switch selectedValue {
+            case "switch":
+                DCSettingOption(value: "switch", label: "Switch")
+            default:
+                DCSettingOption(value: "default", label: "Default")
+            }
+        })
+
+        #expect(setting.value == "fallback")
+        #expect(setting.configuration?.options?.map(\.value) == ["first", "fallback", "third", "fourth", "switch"])
+    }
+
     private enum StringDefaultOption: String, DCSettingOptionProviding {
         case sample
     }

--- a/Tests/DCSettingsTests/DCSettingOptionTests.swift
+++ b/Tests/DCSettingsTests/DCSettingOptionTests.swift
@@ -4,10 +4,10 @@
 //  MIT license, see LICENSE file for details
 //
 
-import XCTest
+import Testing
 @testable import DCSettings
 
-@MainActor final class DCSettingOptionTests: XCTestCase {
+@Suite @MainActor struct DCSettingOptionTests {
 
     private enum TestOption: String, DCSettingOptionProviding {
         case first
@@ -26,70 +26,70 @@ import XCTest
         }
     }
 
-    func testEquatable() {
+    @Test func equatable() {
         let option1 = DCSettingOption(value: "Value1", label: "Label1", image: "Image1")
         let option2 = DCSettingOption(value: "Value1", label: "Label1", image: "Image1")
         let option3 = DCSettingOption(value: "Value2", label: "Label2", image: "Image2")
 
-        XCTAssertEqual(option1, option2)
-        XCTAssertNotEqual(option1, option3)
+        #expect(option1 == option2)
+        #expect(option1 != option3)
     }
 
-    func testLabel() {
+    @Test func label() {
         let option = DCSettingOption(value: "Value", label: "Label", image: "Image")
-        XCTAssertEqual(option.label, "Label")
+        #expect(option.label == "Label")
     }
 
-    func testValue() {
+    @Test func value() {
         let option = DCSettingOption(value: "Value", label: "Label", image: "Image")
-        XCTAssertEqual(option.value, "Value")
+        #expect(option.value == "Value")
     }
 
-    func testCustomImage() {
+    @Test func customImage() {
         let option = DCSettingOption(value: "Value", label: "Label", image: "Image")
-        XCTAssertEqual(option.image, .custom("Image"))
+        #expect(option.image == .custom("Image"))
     }
 
-    func testSystemImage() {
+    @Test func systemImage() {
         let option = DCSettingOption(value: "Value", label: "Label", systemImage: "SystemImage")
-        XCTAssertEqual(option.image, .system("SystemImage"))
+        #expect(option.image == .system("SystemImage"))
     }
 
-    func testDefaultOption() {
+    @Test func defaultOption() {
         let option = DCSettingOption(value: "Value", default: true)
-        XCTAssertTrue(option.isDefault)
+        #expect(option.isDefault)
     }
 
-    func testDefaultModifierReturnsDefaultOption() {
+    @Test func defaultModifierReturnsDefaultOption() {
         let option = DCSettingOption(value: "Value", label: "Label").default()
 
-        XCTAssertTrue(option.isDefault)
-        XCTAssertEqual(option.label, "Label")
-        XCTAssertEqual(option.value, "Value")
+        #expect(option.isDefault)
+        #expect(option.label == "Label")
+        #expect(option.value == "Value")
     }
 
-    func testImageOnlyInitializers() {
+    @Test func imageOnlyInitializers() {
         let customImageOption = DCSettingOption(value: "Value", image: "Image")
         let systemImageOption = DCSettingOption(value: "Value", systemImage: "SystemImage")
 
-        XCTAssertNil(customImageOption.label)
-        XCTAssertEqual(customImageOption.image, .custom("Image"))
-        XCTAssertNil(systemImageOption.label)
-        XCTAssertEqual(systemImageOption.image, .system("SystemImage"))
+        #expect(customImageOption.label == nil)
+        #expect(customImageOption.image == .custom("Image"))
+        #expect(systemImageOption.label == nil)
+        #expect(systemImageOption.image == .system("SystemImage"))
     }
 
-    func testDefaultOptionProvidingImplementations() {
-        XCTAssertNil(StringDefaultOption.defaultCase)
-        XCTAssertNil(StringDefaultOption.sample.label)
-        XCTAssertNil(StringDefaultOption.sample.image)
+    @Test func defaultOptionProvidingImplementations() {
+        #expect(StringDefaultOption.defaultCase == nil)
+        #expect(StringDefaultOption.sample.label == nil)
+        #expect(StringDefaultOption.sample.image == nil)
     }
 
-    func testOptionsProviderInitializerUsesProviderMetadata() {
-        let setting = DCSetting(key: "optionProvider", optionsProvider: TestOption.self)
+    @Test func optionsProviderInitializerUsesProviderMetadata() throws {
+        let setting = try #require(DCSetting(key: "optionProvider", optionsProvider: TestOption.self))
 
-        XCTAssertEqual(setting?.value, TestOption.second.rawValue)
-        XCTAssertEqual(setting?.configuration?.options?.first?.label, "First")
-        XCTAssertEqual(setting?.configuration?.options?.first?.image, .system("first"))
+        #expect(setting.value == TestOption.second.rawValue)
+        #expect(setting.configuration?.options?.first?.label == "First")
+        #expect(setting.configuration?.options?.first?.image == .system("first"))
     }
 
     private enum StringDefaultOption: String, DCSettingOptionProviding {

--- a/Tests/DCSettingsTests/DCSettingOptionTests.swift
+++ b/Tests/DCSettingsTests/DCSettingOptionTests.swift
@@ -88,8 +88,8 @@ final class DCSettingOptionTests: XCTestCase {
         let setting = DCSetting(key: "optionProvider", optionsProvider: TestOption.self)
         
         XCTAssertEqual(setting?.value, TestOption.second.rawValue)
-        XCTAssertEqual(setting?.configuation?.options?.first?.label, "First")
-        XCTAssertEqual(setting?.configuation?.options?.first?.image, .system("first"))
+        XCTAssertEqual(setting?.configuration?.options?.first?.label, "First")
+        XCTAssertEqual(setting?.configuration?.options?.first?.image, .system("first"))
     }
     
     private enum StringDefaultOption: String, DCSettingOptionProviding {

--- a/Tests/DCSettingsTests/DCSettingOptionTests.swift
+++ b/Tests/DCSettingsTests/DCSettingOptionTests.swift
@@ -7,7 +7,7 @@
 import XCTest
 @testable import DCSettings
 
-final class DCSettingOptionTests: XCTestCase {
+@MainActor final class DCSettingOptionTests: XCTestCase {
 
     private enum TestOption: String, DCSettingOptionProviding {
         case first

--- a/Tests/DCSettingsTests/DCSettingOptionTests.swift
+++ b/Tests/DCSettingsTests/DCSettingOptionTests.swift
@@ -8,90 +8,90 @@ import XCTest
 @testable import DCSettings
 
 final class DCSettingOptionTests: XCTestCase {
-    
+
     private enum TestOption: String, DCSettingOptionProviding {
         case first
         case second
-        
+
         static var defaultCase: TestOption? {
             return .second
         }
-        
+
         var label: String? {
             return rawValue.sentenceFormatted
         }
-        
+
         var image: DCImageName? {
             return .system(rawValue)
         }
     }
-    
+
     func testEquatable() {
         let option1 = DCSettingOption(value: "Value1", label: "Label1", image: "Image1")
         let option2 = DCSettingOption(value: "Value1", label: "Label1", image: "Image1")
         let option3 = DCSettingOption(value: "Value2", label: "Label2", image: "Image2")
-        
+
         XCTAssertEqual(option1, option2)
         XCTAssertNotEqual(option1, option3)
     }
-    
+
     func testLabel() {
         let option = DCSettingOption(value: "Value", label: "Label", image: "Image")
         XCTAssertEqual(option.label, "Label")
     }
-    
+
     func testValue() {
         let option = DCSettingOption(value: "Value", label: "Label", image: "Image")
         XCTAssertEqual(option.value, "Value")
     }
-    
+
     func testCustomImage() {
         let option = DCSettingOption(value: "Value", label: "Label", image: "Image")
         XCTAssertEqual(option.image, .custom("Image"))
     }
-    
+
     func testSystemImage() {
         let option = DCSettingOption(value: "Value", label: "Label", systemImage: "SystemImage")
         XCTAssertEqual(option.image, .system("SystemImage"))
     }
-    
+
     func testDefaultOption() {
         let option = DCSettingOption(value: "Value", default: true)
         XCTAssertTrue(option.isDefault)
     }
-    
+
     func testDefaultModifierReturnsDefaultOption() {
         let option = DCSettingOption(value: "Value", label: "Label").default()
-        
+
         XCTAssertTrue(option.isDefault)
         XCTAssertEqual(option.label, "Label")
         XCTAssertEqual(option.value, "Value")
     }
-    
+
     func testImageOnlyInitializers() {
         let customImageOption = DCSettingOption(value: "Value", image: "Image")
         let systemImageOption = DCSettingOption(value: "Value", systemImage: "SystemImage")
-        
+
         XCTAssertNil(customImageOption.label)
         XCTAssertEqual(customImageOption.image, .custom("Image"))
         XCTAssertNil(systemImageOption.label)
         XCTAssertEqual(systemImageOption.image, .system("SystemImage"))
     }
-    
+
     func testDefaultOptionProvidingImplementations() {
         XCTAssertNil(StringDefaultOption.defaultCase)
         XCTAssertNil(StringDefaultOption.sample.label)
         XCTAssertNil(StringDefaultOption.sample.image)
     }
-    
+
     func testOptionsProviderInitializerUsesProviderMetadata() {
         let setting = DCSetting(key: "optionProvider", optionsProvider: TestOption.self)
-        
+
         XCTAssertEqual(setting?.value, TestOption.second.rawValue)
         XCTAssertEqual(setting?.configuration?.options?.first?.label, "First")
         XCTAssertEqual(setting?.configuration?.options?.first?.image, .system("first"))
     }
-    
+
     private enum StringDefaultOption: String, DCSettingOptionProviding {
         case sample
     }

--- a/Tests/DCSettingsTests/DCSettingTests.swift
+++ b/Tests/DCSettingsTests/DCSettingTests.swift
@@ -8,7 +8,7 @@ import XCTest
 @testable import DCSettings
 import Combine
 
-final class DCSettingTests: XCTestCase {
+@MainActor final class DCSettingTests: XCTestCase {
 
     private struct CodableValue: Codable, Equatable {
         let name: String
@@ -30,8 +30,8 @@ final class DCSettingTests: XCTestCase {
     private var setting: DCSetting<String>!
     private var cancellables: Set<AnyCancellable> = []
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         backingStore = MockStore()
         store = .custom(backingStore: backingStore)
         setting = DCSetting(key: "testKey", defaultValue: "defaultValue", store: store)

--- a/Tests/DCSettingsTests/DCSettingTests.swift
+++ b/Tests/DCSettingsTests/DCSettingTests.swift
@@ -6,18 +6,26 @@
 
 import XCTest
 @testable import DCSettings
+import Combine
 
 final class DCSettingTests: XCTestCase {
+    
+    private struct CodableValue: Codable, Equatable {
+        let name: String
+        let count: Int
+    }
 
     private var store: DCSettingStore!
     private var backingStore: MockStore!
     private var setting: DCSetting<String>!
+    private var cancellables: Set<AnyCancellable> = []
     
     override func setUp() {
         super.setUp()
         backingStore = MockStore()
         store = .custom(backingStore: backingStore)
         setting = DCSetting(key: "testKey", defaultValue: "defaultValue", store: store)
+        cancellables = []
     }
     
     func testInitWithDefaultValue() {
@@ -62,5 +70,39 @@ final class DCSettingTests: XCTestCase {
         setting.value = "newValue"
         
         XCTAssertEqual(backingStore?.storage["testKey"] as? String, setting.value)
+    }
+    
+    func testCodableCustomStoreRefreshRoundTrip() {
+        let storedValue = CodableValue(name: "stored", count: 42)
+        let defaultValue = CodableValue(name: "default", count: 0)
+        let setting = DCSetting(key: "codableKey", defaultValue: defaultValue, store: store)
+        
+        setting.value = storedValue
+        
+        XCTAssertTrue(backingStore.storage["codableKey"] is Data)
+        
+        let refreshedSetting = DCSetting(key: "codableKey", defaultValue: defaultValue, store: store)
+        refreshedSetting.refresh()
+        
+        XCTAssertEqual(refreshedSetting.value, storedValue)
+    }
+    
+    func testCodableCustomStorePublisherRoundTrip() {
+        let defaultValue = CodableValue(name: "default", count: 0)
+        let updatedValue = CodableValue(name: "updated", count: 7)
+        let setting = DCSetting(key: "codableKey", defaultValue: defaultValue, store: store)
+        let valueDidChange = expectation(description: "Codable value update was decoded")
+        
+        setting.refresh()
+        setting.objectWillChange
+            .sink {
+                valueDidChange.fulfill()
+            }
+            .store(in: &cancellables)
+        
+        store.set(updatedValue, forKey: "codableKey")
+        
+        wait(for: [valueDidChange], timeout: 1.0)
+        XCTAssertEqual(setting.value, updatedValue)
     }
 }

--- a/Tests/DCSettingsTests/DCSettingTests.swift
+++ b/Tests/DCSettingsTests/DCSettingTests.swift
@@ -20,7 +20,7 @@ import Combine
         let label: String? = nil
         let key = "legacy"
         var value = 1
-        let configuation: DCSettingConfiguration<Int>? = DCSettingConfiguration(options: nil, bounds: nil, step: 1)
+        let configuration: DCSettingConfiguration<Int>? = DCSettingConfiguration(options: nil, bounds: nil, step: 1)
         var store: DCSettingStore?
 
         func refresh() {}
@@ -67,10 +67,16 @@ import Combine
         #expect(setting.configuration?.bounds == DCValueBounds(lowerBound: 0, upperBound: 10))
     }
 
-    @Test func configurationCompatibilityForLegacySettableConformer() {
+    @Test func configurationPropertyIsAccessible() {
         let setting = LegacySettable()
 
         #expect(setting.configuration?.step == 1)
+    }
+
+    @Test func deprecatedConfiguationAliasForwardToConfiguration() {
+        let setting = LegacySettable()
+
+        #expect(setting.configuation?.step == setting.configuration?.step)
     }
 
     @Test func valueBinding() {
@@ -136,5 +142,14 @@ import Combine
 
         #expect(await waitUntil { didChange })
         #expect(setting.value == updatedValue)
+    }
+
+    @Test func externalStoreUpdateDoesNotWriteValueBackToStore() async {
+        setting.refresh()
+
+        store.set("externalValue", forKey: "testKey")
+
+        #expect(await waitUntil { setting.value == "externalValue" })
+        #expect(backingStore.setCallCount(forKey: "testKey") == 1)
     }
 }

--- a/Tests/DCSettingsTests/DCSettingTests.swift
+++ b/Tests/DCSettingsTests/DCSettingTests.swift
@@ -4,11 +4,12 @@
 //  MIT license, see LICENSE file for details
 //
 
-import XCTest
+import Testing
+import Foundation
 @testable import DCSettings
 import Combine
 
-@MainActor final class DCSettingTests: XCTestCase {
+@Suite @MainActor struct DCSettingTests {
 
     private struct CodableValue: Codable, Equatable {
         let name: String
@@ -25,117 +26,115 @@ import Combine
         func refresh() {}
     }
 
-    private var store: DCSettingStore!
-    private var backingStore: MockStore!
-    private var setting: DCSetting<String>!
-    private var cancellables: Set<AnyCancellable> = []
+    private let store: DCSettingStore
+    private let backingStore: MockStore
+    private let setting: DCSetting<String>
 
-    override func setUp() async throws {
-        try await super.setUp()
+    init() {
         backingStore = MockStore()
         store = .custom(backingStore: backingStore)
         setting = DCSetting(key: "testKey", defaultValue: "defaultValue", store: store)
-        cancellables = []
     }
 
-    func testInitWithDefaultValue() {
-        XCTAssertEqual(setting.value, "defaultValue")
+    @Test func initWithDefaultValue() {
+        #expect(setting.value == "defaultValue")
     }
 
-    func testValueChange() {
+    @Test func valueChange() {
         setting.value = "newValue"
 
-        XCTAssertEqual(setting.value, "newValue")
+        #expect(setting.value == "newValue")
     }
 
-    func testRefresh() {
+    @Test func refresh() {
         backingStore.set("anotherValue", forKey: "testKey")
         setting.refresh()
 
-        XCTAssertEqual(setting.value, "anotherValue")
+        #expect(setting.value == "anotherValue")
     }
 
-    func testInitWithOptions() {
+    @Test func initWithOptions() throws {
         let options = ["option1", "option2", "option3"]
-        let setting = DCSetting(key: "testKey", store: store, options: options, defaultIndex: 1)
+        let setting = try #require(DCSetting(key: "testKey", store: store, options: options, defaultIndex: 1))
 
-        XCTAssertEqual(setting?.value, "option2")
+        #expect(setting.value == "option2")
     }
 
-    func testInitWithBounds() {
+    @Test func initWithBounds() {
         let setting = DCSetting(key: "testKey", defaultValue: 5, store: store, lowerBound: 0, upperBound: 10)
 
-        XCTAssertEqual(setting.value, 5)
-        XCTAssertEqual(setting.configuration?.bounds, DCValueBounds(lowerBound: 0, upperBound: 10))
+        #expect(setting.value == 5)
+        #expect(setting.configuration?.bounds == DCValueBounds(lowerBound: 0, upperBound: 10))
     }
 
-    func testConfigurationCompatibilityForLegacySettableConformer() {
+    @Test func configurationCompatibilityForLegacySettableConformer() {
         let setting = LegacySettable()
 
-        XCTAssertEqual(setting.configuration?.step, 1)
+        #expect(setting.configuration?.step == 1)
     }
 
-    func testValueBinding() {
+    @Test func valueBinding() {
         let binding = setting.valueBinding()
         binding.wrappedValue = "newValue"
 
-        XCTAssertEqual(setting.value, "newValue")
+        #expect(setting.value == "newValue")
     }
 
-    func testStoreSet() {
+    @Test func storeSet() {
         setting.value = "newValue"
 
-        XCTAssertEqual(backingStore?.storage["testKey"] as? String, setting.value)
+        #expect(backingStore.storage["testKey"] as? String == setting.value)
     }
 
-    func testRefreshNotifiesObserversWhenValueChanges() {
-        let valueDidRefresh = expectation(description: "Setting refresh emitted a change")
+    @Test func refreshNotifiesObserversWhenValueChanges() async {
+        var didRefresh = false
+        var cancellables: Set<AnyCancellable> = []
 
         setting.objectWillChange
             .sink {
-                XCTAssertEqual(self.setting.value, "anotherValue")
-                valueDidRefresh.fulfill()
+                didRefresh = true
             }
             .store(in: &cancellables)
 
         backingStore.storage["testKey"] = "anotherValue"
         setting.refresh()
 
-        wait(for: [valueDidRefresh], timeout: 1.0)
-        XCTAssertEqual(setting.value, "anotherValue")
+        #expect(await waitUntil { didRefresh })
+        #expect(setting.value == "anotherValue")
     }
 
-    func testCodableCustomStoreRefreshRoundTrip() {
+    @Test func codableCustomStoreRefreshRoundTrip() {
         let storedValue = CodableValue(name: "stored", count: 42)
         let defaultValue = CodableValue(name: "default", count: 0)
         let setting = DCSetting(key: "codableKey", defaultValue: defaultValue, store: store)
 
         setting.value = storedValue
 
-        XCTAssertTrue(backingStore.storage["codableKey"] is Data)
+        #expect(backingStore.storage["codableKey"] is Data)
 
         let refreshedSetting = DCSetting(key: "codableKey", defaultValue: defaultValue, store: store)
         refreshedSetting.refresh()
 
-        XCTAssertEqual(refreshedSetting.value, storedValue)
+        #expect(refreshedSetting.value == storedValue)
     }
 
-    func testCodableCustomStorePublisherRoundTrip() {
+    @Test func codableCustomStorePublisherRoundTrip() async {
         let defaultValue = CodableValue(name: "default", count: 0)
         let updatedValue = CodableValue(name: "updated", count: 7)
         let setting = DCSetting(key: "codableKey", defaultValue: defaultValue, store: store)
-        let valueDidChange = expectation(description: "Codable value update was decoded")
+        var didChange = false
+        var cancellables: Set<AnyCancellable> = []
 
         setting.refresh()
         setting.objectWillChange
             .sink {
-                valueDidChange.fulfill()
+                didChange = true
             }
             .store(in: &cancellables)
 
         store.set(updatedValue, forKey: "codableKey")
 
-        wait(for: [valueDidChange], timeout: 1.0)
-        XCTAssertEqual(setting.value, updatedValue)
+        #expect(await waitUntil { didChange })
+        #expect(setting.value == updatedValue)
     }
 }

--- a/Tests/DCSettingsTests/DCSettingTests.swift
+++ b/Tests/DCSettingsTests/DCSettingTests.swift
@@ -56,7 +56,7 @@ final class DCSettingTests: XCTestCase {
         let setting = DCSetting(key: "testKey", defaultValue: 5, store: store, lowerBound: 0, upperBound: 10)
         
         XCTAssertEqual(setting.value, 5)
-        XCTAssertEqual(setting.configuation?.bounds, DCValueBounds(lowerBound: 0, upperBound: 10))
+        XCTAssertEqual(setting.configuration?.bounds, DCValueBounds(lowerBound: 0, upperBound: 10))
     }
 
     func testValueBinding() {
@@ -70,6 +70,23 @@ final class DCSettingTests: XCTestCase {
         setting.value = "newValue"
         
         XCTAssertEqual(backingStore?.storage["testKey"] as? String, setting.value)
+    }
+    
+    func testRefreshNotifiesObserversWhenValueChanges() {
+        let valueDidRefresh = expectation(description: "Setting refresh emitted a change")
+        
+        setting.objectWillChange
+            .sink {
+                XCTAssertEqual(self.setting.value, "anotherValue")
+                valueDidRefresh.fulfill()
+            }
+            .store(in: &cancellables)
+        
+        backingStore.storage["testKey"] = "anotherValue"
+        setting.refresh()
+        
+        wait(for: [valueDidRefresh], timeout: 1.0)
+        XCTAssertEqual(setting.value, "anotherValue")
     }
     
     func testCodableCustomStoreRefreshRoundTrip() {

--- a/Tests/DCSettingsTests/DCSettingTests.swift
+++ b/Tests/DCSettingsTests/DCSettingTests.swift
@@ -9,17 +9,27 @@ import XCTest
 import Combine
 
 final class DCSettingTests: XCTestCase {
-    
+
     private struct CodableValue: Codable, Equatable {
         let name: String
         let count: Int
+    }
+
+    private final class LegacySettable: DCSettable {
+        let label: String? = nil
+        let key = "legacy"
+        var value = 1
+        let configuation: DCSettingConfiguration<Int>? = DCSettingConfiguration(options: nil, bounds: nil, step: 1)
+        var store: DCSettingStore?
+
+        func refresh() {}
     }
 
     private var store: DCSettingStore!
     private var backingStore: MockStore!
     private var setting: DCSetting<String>!
     private var cancellables: Set<AnyCancellable> = []
-    
+
     override func setUp() {
         super.setUp()
         backingStore = MockStore()
@@ -27,98 +37,104 @@ final class DCSettingTests: XCTestCase {
         setting = DCSetting(key: "testKey", defaultValue: "defaultValue", store: store)
         cancellables = []
     }
-    
+
     func testInitWithDefaultValue() {
         XCTAssertEqual(setting.value, "defaultValue")
     }
-    
+
     func testValueChange() {
         setting.value = "newValue"
-        
+
         XCTAssertEqual(setting.value, "newValue")
     }
-    
+
     func testRefresh() {
         backingStore.set("anotherValue", forKey: "testKey")
         setting.refresh()
-        
+
         XCTAssertEqual(setting.value, "anotherValue")
     }
-    
+
     func testInitWithOptions() {
         let options = ["option1", "option2", "option3"]
         let setting = DCSetting(key: "testKey", store: store, options: options, defaultIndex: 1)
-        
+
         XCTAssertEqual(setting?.value, "option2")
     }
 
     func testInitWithBounds() {
         let setting = DCSetting(key: "testKey", defaultValue: 5, store: store, lowerBound: 0, upperBound: 10)
-        
+
         XCTAssertEqual(setting.value, 5)
         XCTAssertEqual(setting.configuration?.bounds, DCValueBounds(lowerBound: 0, upperBound: 10))
+    }
+
+    func testConfigurationCompatibilityForLegacySettableConformer() {
+        let setting = LegacySettable()
+
+        XCTAssertEqual(setting.configuration?.step, 1)
     }
 
     func testValueBinding() {
         let binding = setting.valueBinding()
         binding.wrappedValue = "newValue"
-        
+
         XCTAssertEqual(setting.value, "newValue")
     }
-    
+
     func testStoreSet() {
         setting.value = "newValue"
-        
+
         XCTAssertEqual(backingStore?.storage["testKey"] as? String, setting.value)
     }
-    
+
     func testRefreshNotifiesObserversWhenValueChanges() {
         let valueDidRefresh = expectation(description: "Setting refresh emitted a change")
-        
+
         setting.objectWillChange
             .sink {
                 XCTAssertEqual(self.setting.value, "anotherValue")
                 valueDidRefresh.fulfill()
             }
             .store(in: &cancellables)
-        
+
         backingStore.storage["testKey"] = "anotherValue"
         setting.refresh()
-        
+
         wait(for: [valueDidRefresh], timeout: 1.0)
         XCTAssertEqual(setting.value, "anotherValue")
     }
-    
+
     func testCodableCustomStoreRefreshRoundTrip() {
         let storedValue = CodableValue(name: "stored", count: 42)
         let defaultValue = CodableValue(name: "default", count: 0)
         let setting = DCSetting(key: "codableKey", defaultValue: defaultValue, store: store)
-        
+
         setting.value = storedValue
-        
+
         XCTAssertTrue(backingStore.storage["codableKey"] is Data)
-        
+
         let refreshedSetting = DCSetting(key: "codableKey", defaultValue: defaultValue, store: store)
         refreshedSetting.refresh()
-        
+
         XCTAssertEqual(refreshedSetting.value, storedValue)
     }
-    
+
     func testCodableCustomStorePublisherRoundTrip() {
         let defaultValue = CodableValue(name: "default", count: 0)
         let updatedValue = CodableValue(name: "updated", count: 7)
         let setting = DCSetting(key: "codableKey", defaultValue: defaultValue, store: store)
         let valueDidChange = expectation(description: "Codable value update was decoded")
-        
+
         setting.refresh()
         setting.objectWillChange
             .sink {
                 valueDidChange.fulfill()
             }
             .store(in: &cancellables)
-        
+
         store.set(updatedValue, forKey: "codableKey")
-        
+
         wait(for: [valueDidChange], timeout: 1.0)
         XCTAssertEqual(setting.value, updatedValue)
     }

--- a/Tests/DCSettingsTests/DCSettingViewTests.swift
+++ b/Tests/DCSettingsTests/DCSettingViewTests.swift
@@ -8,37 +8,37 @@ import XCTest
 @testable import DCSettings
 
 final class DCSettingViewTests: XCTestCase {
-    
+
     func testDisplayLabelUsesExplicitLabel() {
         let setting = DCSetting(key: "articleListLayout", defaultValue: true, label: "Layout")
-        
+
         XCTAssertEqual(setting.displayLabel, "Layout")
     }
-    
+
     func testDisplayLabelFormatsKeyWhenLabelIsMissing() {
         let setting = DCSetting(key: "articleListLayout", defaultValue: true)
-        
+
         XCTAssertEqual(setting.displayLabel, "Article list layout")
     }
-    
+
     func testOptionControlStyleUsesPickerForTwoOrFewerOptions() {
         XCTAssertEqual(DCOptionControlStyle(optionCount: 0), .picker)
         XCTAssertEqual(DCOptionControlStyle(optionCount: 1), .picker)
         XCTAssertEqual(DCOptionControlStyle(optionCount: 2), .picker)
     }
-    
+
     func testOptionControlStyleUsesMenuPickerForMoreThanTwoOptions() {
         XCTAssertEqual(DCOptionControlStyle(optionCount: 3), .menuPicker)
         XCTAssertEqual(DCOptionControlStyle(optionCount: 10), .menuPicker)
     }
-    
+
     func testDatePickerRangeUsesLowerAndUpperBounds() {
         let lowerBound = Date(timeIntervalSince1970: 1_704_067_200)
         let upperBound = Date(timeIntervalSince1970: 1_735_689_600)
         let bounds = DCValueBounds(lowerBound: lowerBound, upperBound: upperBound)
-        
+
         let range = DCDateSettingView.datePickerRange(for: bounds)
-        
+
         XCTAssertEqual(range.lowerBound, lowerBound)
         XCTAssertEqual(range.upperBound, upperBound)
     }

--- a/Tests/DCSettingsTests/DCSettingViewTests.swift
+++ b/Tests/DCSettingsTests/DCSettingViewTests.swift
@@ -7,7 +7,7 @@
 import XCTest
 @testable import DCSettings
 
-final class DCSettingViewTests: XCTestCase {
+@MainActor final class DCSettingViewTests: XCTestCase {
 
     func testDisplayLabelUsesExplicitLabel() {
         let setting = DCSetting(key: "articleListLayout", defaultValue: true, label: "Layout")

--- a/Tests/DCSettingsTests/DCSettingViewTests.swift
+++ b/Tests/DCSettingsTests/DCSettingViewTests.swift
@@ -1,0 +1,35 @@
+//
+//  DCSettings
+//  Copyright (c) David Caddy 2023
+//  MIT license, see LICENSE file for details
+//
+
+import XCTest
+@testable import DCSettings
+
+final class DCSettingViewTests: XCTestCase {
+    
+    func testDisplayLabelUsesExplicitLabel() {
+        let setting = DCSetting(key: "articleListLayout", defaultValue: true, label: "Layout")
+        
+        XCTAssertEqual(setting.displayLabel, "Layout")
+    }
+    
+    func testDisplayLabelFormatsKeyWhenLabelIsMissing() {
+        let setting = DCSetting(key: "articleListLayout", defaultValue: true)
+        
+        XCTAssertEqual(setting.displayLabel, "Article list layout")
+    }
+    
+    func testOptionControlStyleUsesPickerForTwoOrFewerOptions() {
+        XCTAssertEqual(DCOptionControlStyle(optionCount: 0), .picker)
+        XCTAssertEqual(DCOptionControlStyle(optionCount: 1), .picker)
+        XCTAssertEqual(DCOptionControlStyle(optionCount: 2), .picker)
+    }
+    
+    func testOptionControlStyleUsesMenuPickerForMoreThanTwoOptions() {
+        XCTAssertEqual(DCOptionControlStyle(optionCount: 3), .menuPicker)
+        XCTAssertEqual(DCOptionControlStyle(optionCount: 10), .menuPicker)
+    }
+}
+

--- a/Tests/DCSettingsTests/DCSettingViewTests.swift
+++ b/Tests/DCSettingsTests/DCSettingViewTests.swift
@@ -4,42 +4,43 @@
 //  MIT license, see LICENSE file for details
 //
 
-import XCTest
+import Testing
+import Foundation
 @testable import DCSettings
 
-@MainActor final class DCSettingViewTests: XCTestCase {
+@Suite @MainActor struct DCSettingViewTests {
 
-    func testDisplayLabelUsesExplicitLabel() {
+    @Test func displayLabelUsesExplicitLabel() {
         let setting = DCSetting(key: "articleListLayout", defaultValue: true, label: "Layout")
 
-        XCTAssertEqual(setting.displayLabel, "Layout")
+        #expect(setting.displayLabel == "Layout")
     }
 
-    func testDisplayLabelFormatsKeyWhenLabelIsMissing() {
+    @Test func displayLabelFormatsKeyWhenLabelIsMissing() {
         let setting = DCSetting(key: "articleListLayout", defaultValue: true)
 
-        XCTAssertEqual(setting.displayLabel, "Article list layout")
+        #expect(setting.displayLabel == "Article list layout")
     }
 
-    func testOptionControlStyleUsesPickerForTwoOrFewerOptions() {
-        XCTAssertEqual(DCOptionControlStyle(optionCount: 0), .picker)
-        XCTAssertEqual(DCOptionControlStyle(optionCount: 1), .picker)
-        XCTAssertEqual(DCOptionControlStyle(optionCount: 2), .picker)
+    @Test func optionControlStyleUsesPickerForTwoOrFewerOptions() {
+        #expect(DCOptionControlStyle(optionCount: 0) == .picker)
+        #expect(DCOptionControlStyle(optionCount: 1) == .picker)
+        #expect(DCOptionControlStyle(optionCount: 2) == .picker)
     }
 
-    func testOptionControlStyleUsesMenuPickerForMoreThanTwoOptions() {
-        XCTAssertEqual(DCOptionControlStyle(optionCount: 3), .menuPicker)
-        XCTAssertEqual(DCOptionControlStyle(optionCount: 10), .menuPicker)
+    @Test func optionControlStyleUsesMenuPickerForMoreThanTwoOptions() {
+        #expect(DCOptionControlStyle(optionCount: 3) == .menuPicker)
+        #expect(DCOptionControlStyle(optionCount: 10) == .menuPicker)
     }
 
-    func testDatePickerRangeUsesLowerAndUpperBounds() {
+    @Test func datePickerRangeUsesLowerAndUpperBounds() {
         let lowerBound = Date(timeIntervalSince1970: 1_704_067_200)
         let upperBound = Date(timeIntervalSince1970: 1_735_689_600)
         let bounds = DCValueBounds(lowerBound: lowerBound, upperBound: upperBound)
 
         let range = DCDateSettingView.datePickerRange(for: bounds)
 
-        XCTAssertEqual(range.lowerBound, lowerBound)
-        XCTAssertEqual(range.upperBound, upperBound)
+        #expect(range.lowerBound == lowerBound)
+        #expect(range.upperBound == upperBound)
     }
 }

--- a/Tests/DCSettingsTests/DCSettingViewTests.swift
+++ b/Tests/DCSettingsTests/DCSettingViewTests.swift
@@ -31,5 +31,15 @@ final class DCSettingViewTests: XCTestCase {
         XCTAssertEqual(DCOptionControlStyle(optionCount: 3), .menuPicker)
         XCTAssertEqual(DCOptionControlStyle(optionCount: 10), .menuPicker)
     }
+    
+    func testDatePickerRangeUsesLowerAndUpperBounds() {
+        let lowerBound = Date(timeIntervalSince1970: 1_704_067_200)
+        let upperBound = Date(timeIntervalSince1970: 1_735_689_600)
+        let bounds = DCValueBounds(lowerBound: lowerBound, upperBound: upperBound)
+        
+        let range = DCDateSettingView.datePickerRange(for: bounds)
+        
+        XCTAssertEqual(range.lowerBound, lowerBound)
+        XCTAssertEqual(range.upperBound, upperBound)
+    }
 }
-

--- a/Tests/DCSettingsTests/DCSettingsManagerTests.swift
+++ b/Tests/DCSettingsTests/DCSettingsManagerTests.swift
@@ -9,7 +9,7 @@ import XCTest
 import SwiftUI
 import Combine
 
-class DCSettingsManagerTests: XCTestCase {
+@MainActor class DCSettingsManagerTests: XCTestCase {
 
     private enum TestEnum: String, Equatable, CaseIterable {
         case case1
@@ -21,8 +21,8 @@ class DCSettingsManagerTests: XCTestCase {
     private var manager: DCSettingsManager!
     private var cancellables: Set<AnyCancellable> = []
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         backingStore = MockStore()
         store = .custom(backingStore: backingStore)
         manager = DCSettingsManager()

--- a/Tests/DCSettingsTests/DCSettingsManagerTests.swift
+++ b/Tests/DCSettingsTests/DCSettingsManagerTests.swift
@@ -66,11 +66,44 @@ import Combine
         #expect(!manager.set("newValue", forKey: "nonExistentKey"))
     }
 
+    @Test func setReturnsFalseForMismatchedValueType() {
+        #expect(!manager.set(42, forKey: "key1"))
+        #expect(manager.string(forKey: "key1") == "value1")
+        #expect(backingStore.storage["key1"] == nil)
+    }
+
+    @Test func configureReplacesCachedSettings() {
+        manager.configure {
+            DCSettingGroup("Replacement", store: store) {
+                DCSetting(key: "replacementKey", defaultValue: "replacement")
+            }
+        }
+
+        #expect(manager.setting(forKey: "key1") == nil)
+        #expect(manager.string(forKey: "replacementKey") == "replacement")
+    }
+
     @Test func settingForKey() throws {
         let setting = try #require(manager.setting(forKey: "key1") as? DCSetting<String>)
 
         #expect(setting.value == "value1")
         #expect(manager.setting(forKey: "nonExistentKey") == nil)
+    }
+
+    @Test func duplicateSettingKeysKeepFirstConfiguredSetting() throws {
+        let manager = DCSettingsManager()
+
+        manager.configure {
+            DCSettingGroup("Group 1", store: store) {
+                DCSetting(key: "duplicateKey", defaultValue: "first")
+            }
+            DCSettingGroup("Group 2", store: store) {
+                DCSetting(key: "duplicateKey", defaultValue: "second")
+            }
+        }
+
+        let setting = try #require(manager.setting(forKey: "duplicateKey") as? DCSetting<String>)
+        #expect(setting.value == "first")
     }
 
     @Test func valueForKey() {

--- a/Tests/DCSettingsTests/DCSettingsManagerTests.swift
+++ b/Tests/DCSettingsTests/DCSettingsManagerTests.swift
@@ -4,29 +4,26 @@
 //  MIT license, see LICENSE file for details
 //
 
-import XCTest
+import Testing
 @testable import DCSettings
 import SwiftUI
 import Combine
 
-@MainActor class DCSettingsManagerTests: XCTestCase {
+@Suite @MainActor struct DCSettingsManagerTests {
 
     private enum TestEnum: String, Equatable, CaseIterable {
         case case1
         case case2
     }
 
-    private var backingStore: MockStore!
-    private var store: DCSettingStore!
-    private var manager: DCSettingsManager!
-    private var cancellables: Set<AnyCancellable> = []
+    private let backingStore: MockStore
+    private let store: DCSettingStore
+    private let manager: DCSettingsManager
 
-    override func setUp() async throws {
-        try await super.setUp()
+    init() {
         backingStore = MockStore()
         store = .custom(backingStore: backingStore)
         manager = DCSettingsManager()
-        cancellables = []
 
         manager.configure {
             DCSettingGroup("Group 1", store: store) {
@@ -43,125 +40,116 @@ import Combine
         }
     }
 
-    func testConfigureWithSettingGroups() {
-        XCTAssertEqual(manager.groups.count, 2)
-        XCTAssertEqual(manager.groups[0].label, "Group 1")
-        XCTAssertEqual(manager.groups[1].label, "Group 2")
+    @Test func configureWithSettingGroups() {
+        #expect(manager.groups.count == 2)
+        #expect(manager.groups[0].label == "Group 1")
+        #expect(manager.groups[1].label == "Group 2")
     }
 
-    func testSetAndGetValue() {
-        XCTAssertTrue(manager.bool(forKey: "key3"))
+    @Test func setAndGetValue() {
+        #expect(manager.bool(forKey: "key3"))
 
         manager.set(false, forKey: "key3")
 
-        XCTAssertFalse(manager.bool(forKey: "key3"))
+        #expect(!manager.bool(forKey: "key3"))
     }
 
-    func testConfigure() {
-        XCTAssertEqual(manager.groups.count, 2)
-        XCTAssertEqual(manager.groups.first?.settings.count, 2)
-        XCTAssertEqual(manager.groups.last?.settings.count, 5)
+    @Test func configure() {
+        #expect(manager.groups.count == 2)
+        #expect(manager.groups.first?.settings.count == 2)
+        #expect(manager.groups.last?.settings.count == 5)
     }
 
-    func testSet() {
-        XCTAssertTrue(manager.set("newValue", forKey: "key1"))
-        XCTAssertEqual(backingStore.storage["key1"] as? String, "newValue")
-        XCTAssertFalse(manager.set("newValue", forKey: "nonExistentKey"))
+    @Test func set() {
+        #expect(manager.set("newValue", forKey: "key1"))
+        #expect(backingStore.storage["key1"] as? String == "newValue")
+        #expect(!manager.set("newValue", forKey: "nonExistentKey"))
     }
 
-    func testSettingForKey() {
-        let setting = manager.setting(forKey: "key1") as? DCSetting<String>
+    @Test func settingForKey() throws {
+        let setting = try #require(manager.setting(forKey: "key1") as? DCSetting<String>)
 
-        XCTAssertNotNil(setting)
-        XCTAssertEqual(setting?.value, "value1")
-        XCTAssertNil(manager.setting(forKey: "nonExistentKey"))
+        #expect(setting.value == "value1")
+        #expect(manager.setting(forKey: "nonExistentKey") == nil)
     }
 
-    func testValueForKey() {
+    @Test func valueForKey() {
         let value: String? = manager.value(forKey: "key1")
 
-        XCTAssertEqual(value, "value1")
-        XCTAssertNil(manager.value(forKey: "nonExistentKey") as String?)
+        #expect(value == "value1")
+        #expect((manager.value(forKey: "nonExistentKey") as String?) == nil)
     }
 
-    func testValuePublisherEmitsCurrentAndChangedValue() {
-        let valuesDidEmit = expectation(description: "Value publisher emitted current and changed values")
+    @Test func valuePublisherEmitsCurrentAndChangedValue() async {
         var receivedValues: [String] = []
+        var cancellables: Set<AnyCancellable> = []
 
         manager.valuePublisher(forKey: "key1")?
             .sink { value in
                 receivedValues.append(value)
-                if receivedValues.count == 2 {
-                    valuesDidEmit.fulfill()
-                }
             }
             .store(in: &cancellables)
 
         manager.set("newValue", forKey: "key1")
 
-        wait(for: [valuesDidEmit], timeout: 1.0)
-        XCTAssertEqual(receivedValues, ["value1", "newValue"])
+        #expect(await waitUntil { receivedValues.count == 2 })
+        #expect(receivedValues == ["value1", "newValue"])
     }
 
-    func testRepresentedValueForKey() {
+    @Test func representedValueForKey() {
         let value: TestEnum? = manager.representedValue(forKey: "key4")
 
-        XCTAssertEqual(value, TestEnum.case1)
-        XCTAssertNil(manager.representedValue(forKey: "nonExistentKey") as TestEnum?)
+        #expect(value == TestEnum.case1)
+        #expect((manager.representedValue(forKey: "nonExistentKey") as TestEnum?) == nil)
     }
 
-    func testRepresentedValuePublisherEmitsCurrentAndChangedValue() {
-        let valuesDidEmit = expectation(description: "Represented value publisher emitted current and changed values")
+    @Test func representedValuePublisherEmitsCurrentAndChangedValue() async {
         var receivedValues: [TestEnum?] = []
+        var cancellables: Set<AnyCancellable> = []
 
         manager.representedValuePublisher(forKey: "key4")?
             .sink { value in
                 receivedValues.append(value)
-                if receivedValues.count == 2 {
-                    valuesDidEmit.fulfill()
-                }
             }
             .store(in: &cancellables)
 
         manager.set(TestEnum.case2.rawValue, forKey: "key4")
 
-        wait(for: [valuesDidEmit], timeout: 1.0)
-        XCTAssertEqual(receivedValues, [.case1, .case2])
+        #expect(await waitUntil { receivedValues.count == 2 })
+        #expect(receivedValues == [.case1, .case2])
     }
 
-    func testValueBindingForKey() {
-        let binding = manager.valueBinding(forKey: "key1") as Binding<String>?
+    @Test func valueBindingForKey() throws {
+        let binding = try #require(manager.valueBinding(forKey: "key1") as Binding<String>?)
 
-        XCTAssertNotNil(binding)
+        binding.wrappedValue = "newValue"
 
-        binding?.wrappedValue = "newValue"
-
-        XCTAssertEqual(backingStore.storage["key1"] as? String, "newValue")
-        XCTAssertNil(manager.valueBinding(forKey: "nonExistentKey") as Binding<String>?)
+        #expect(backingStore.storage["key1"] as? String == "newValue")
+        #expect((manager.valueBinding(forKey: "nonExistentKey") as Binding<String>?) == nil)
     }
 
-    func testBoolForKey() {
-        XCTAssertTrue(manager.bool(forKey: "key3"))
-        XCTAssertFalse(manager.bool(forKey: "nonExistentKey"))
+    @Test func boolForKey() {
+        #expect(manager.bool(forKey: "key3"))
+        #expect(!manager.bool(forKey: "nonExistentKey"))
     }
 
-    func testIntForKey() {
-        XCTAssertTrue(manager.int(forKey: "key2") == 2)
-        XCTAssertTrue(manager.int(forKey: "nonExistentKey") == 0)
+    @Test func intForKey() {
+        #expect(manager.int(forKey: "key2") == 2)
+        #expect(manager.int(forKey: "nonExistentKey") == 0)
     }
 
-    func testDoubleForKey() {
-        XCTAssertTrue(manager.double(forKey: "key5") == 5.0)
-        XCTAssertTrue(manager.double(forKey: "nonExistentKey") == 0.0)
+    @Test func doubleForKey() {
+        #expect(manager.double(forKey: "key5") == 5.0)
+        #expect(manager.double(forKey: "nonExistentKey") == 0.0)
     }
 
-    func testStringForKey() {
-        XCTAssertEqual(manager.string(forKey: "key7"), "value2")
-        XCTAssertEqual(manager.string(forKey: "nonExistentKey"), "")
+    @Test func stringForKey() {
+        #expect(manager.string(forKey: "key7") == "value2")
+        #expect(manager.string(forKey: "nonExistentKey") == "")
     }
 
-    func testDateForKey() {
-        XCTAssertEqual(manager.date(forKey: "key6"), Date.distantFuture)
-        XCTAssertEqual(manager.date(forKey: "nonExistentKey"), .distantPast)
+    @Test func dateForKey() {
+        #expect(manager.date(forKey: "key6") == Date.distantFuture)
+        #expect(manager.date(forKey: "nonExistentKey") == .distantPast)
     }
 }

--- a/Tests/DCSettingsTests/DCSettingsManagerTests.swift
+++ b/Tests/DCSettingsTests/DCSettingsManagerTests.swift
@@ -7,22 +7,26 @@
 import XCTest
 @testable import DCSettings
 import SwiftUI
+import Combine
 
 class DCSettingsManagerTests: XCTestCase {
     
     private enum TestEnum: String, Equatable, CaseIterable {
         case case1
+        case case2
     }
     
     private var backingStore: MockStore!
     private var store: DCSettingStore!
     private var manager: DCSettingsManager!
+    private var cancellables: Set<AnyCancellable> = []
     
     override func setUp() {
         super.setUp()
         backingStore = MockStore()
         store = .custom(backingStore: backingStore)
         manager = DCSettingsManager()
+        cancellables = []
         
         manager.configure {
             DCSettingGroup("Group 1", store: store) {
@@ -80,11 +84,49 @@ class DCSettingsManagerTests: XCTestCase {
         XCTAssertNil(manager.value(forKey: "nonExistentKey") as String?)
     }
     
+    func testValuePublisherEmitsCurrentAndChangedValue() {
+        let valuesDidEmit = expectation(description: "Value publisher emitted current and changed values")
+        var receivedValues: [String] = []
+        
+        manager.valuePublisher(forKey: "key1")?
+            .sink { value in
+                receivedValues.append(value)
+                if receivedValues.count == 2 {
+                    valuesDidEmit.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+        
+        manager.set("newValue", forKey: "key1")
+        
+        wait(for: [valuesDidEmit], timeout: 1.0)
+        XCTAssertEqual(receivedValues, ["value1", "newValue"])
+    }
+    
     func testRepresentedValueForKey() {
         let value: TestEnum? = manager.representedValue(forKey: "key4")
         
         XCTAssertEqual(value, TestEnum.case1)
         XCTAssertNil(manager.representedValue(forKey: "nonExistentKey") as TestEnum?)
+    }
+    
+    func testRepresentedValuePublisherEmitsCurrentAndChangedValue() {
+        let valuesDidEmit = expectation(description: "Represented value publisher emitted current and changed values")
+        var receivedValues: [TestEnum?] = []
+        
+        manager.representedValuePublisher(forKey: "key4")?
+            .sink { value in
+                receivedValues.append(value)
+                if receivedValues.count == 2 {
+                    valuesDidEmit.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+        
+        manager.set(TestEnum.case2.rawValue, forKey: "key4")
+        
+        wait(for: [valuesDidEmit], timeout: 1.0)
+        XCTAssertEqual(receivedValues, [.case1, .case2])
     }
     
     func testValueBindingForKey() {

--- a/Tests/DCSettingsTests/DCSettingsManagerTests.swift
+++ b/Tests/DCSettingsTests/DCSettingsManagerTests.swift
@@ -10,24 +10,24 @@ import SwiftUI
 import Combine
 
 class DCSettingsManagerTests: XCTestCase {
-    
+
     private enum TestEnum: String, Equatable, CaseIterable {
         case case1
         case case2
     }
-    
+
     private var backingStore: MockStore!
     private var store: DCSettingStore!
     private var manager: DCSettingsManager!
     private var cancellables: Set<AnyCancellable> = []
-    
+
     override func setUp() {
         super.setUp()
         backingStore = MockStore()
         store = .custom(backingStore: backingStore)
         manager = DCSettingsManager()
         cancellables = []
-        
+
         manager.configure {
             DCSettingGroup("Group 1", store: store) {
                 DCSetting(key: "key1", defaultValue: "value1")
@@ -56,38 +56,38 @@ class DCSettingsManagerTests: XCTestCase {
 
         XCTAssertFalse(manager.bool(forKey: "key3"))
     }
-    
+
     func testConfigure() {
         XCTAssertEqual(manager.groups.count, 2)
         XCTAssertEqual(manager.groups.first?.settings.count, 2)
         XCTAssertEqual(manager.groups.last?.settings.count, 5)
     }
-    
+
     func testSet() {
         XCTAssertTrue(manager.set("newValue", forKey: "key1"))
         XCTAssertEqual(backingStore.storage["key1"] as? String, "newValue")
         XCTAssertFalse(manager.set("newValue", forKey: "nonExistentKey"))
     }
-    
+
     func testSettingForKey() {
         let setting = manager.setting(forKey: "key1") as? DCSetting<String>
-        
+
         XCTAssertNotNil(setting)
         XCTAssertEqual(setting?.value, "value1")
         XCTAssertNil(manager.setting(forKey: "nonExistentKey"))
     }
-    
+
     func testValueForKey() {
         let value: String? = manager.value(forKey: "key1")
-        
+
         XCTAssertEqual(value, "value1")
         XCTAssertNil(manager.value(forKey: "nonExistentKey") as String?)
     }
-    
+
     func testValuePublisherEmitsCurrentAndChangedValue() {
         let valuesDidEmit = expectation(description: "Value publisher emitted current and changed values")
         var receivedValues: [String] = []
-        
+
         manager.valuePublisher(forKey: "key1")?
             .sink { value in
                 receivedValues.append(value)
@@ -96,24 +96,24 @@ class DCSettingsManagerTests: XCTestCase {
                 }
             }
             .store(in: &cancellables)
-        
+
         manager.set("newValue", forKey: "key1")
-        
+
         wait(for: [valuesDidEmit], timeout: 1.0)
         XCTAssertEqual(receivedValues, ["value1", "newValue"])
     }
-    
+
     func testRepresentedValueForKey() {
         let value: TestEnum? = manager.representedValue(forKey: "key4")
-        
+
         XCTAssertEqual(value, TestEnum.case1)
         XCTAssertNil(manager.representedValue(forKey: "nonExistentKey") as TestEnum?)
     }
-    
+
     func testRepresentedValuePublisherEmitsCurrentAndChangedValue() {
         let valuesDidEmit = expectation(description: "Represented value publisher emitted current and changed values")
         var receivedValues: [TestEnum?] = []
-        
+
         manager.representedValuePublisher(forKey: "key4")?
             .sink { value in
                 receivedValues.append(value)
@@ -122,44 +122,44 @@ class DCSettingsManagerTests: XCTestCase {
                 }
             }
             .store(in: &cancellables)
-        
+
         manager.set(TestEnum.case2.rawValue, forKey: "key4")
-        
+
         wait(for: [valuesDidEmit], timeout: 1.0)
         XCTAssertEqual(receivedValues, [.case1, .case2])
     }
-    
+
     func testValueBindingForKey() {
         let binding = manager.valueBinding(forKey: "key1") as Binding<String>?
-        
+
         XCTAssertNotNil(binding)
-        
+
         binding?.wrappedValue = "newValue"
-        
+
         XCTAssertEqual(backingStore.storage["key1"] as? String, "newValue")
         XCTAssertNil(manager.valueBinding(forKey: "nonExistentKey") as Binding<String>?)
     }
-    
+
     func testBoolForKey() {
         XCTAssertTrue(manager.bool(forKey: "key3"))
         XCTAssertFalse(manager.bool(forKey: "nonExistentKey"))
     }
-    
+
     func testIntForKey() {
         XCTAssertTrue(manager.int(forKey: "key2") == 2)
         XCTAssertTrue(manager.int(forKey: "nonExistentKey") == 0)
     }
-    
+
     func testDoubleForKey() {
         XCTAssertTrue(manager.double(forKey: "key5") == 5.0)
         XCTAssertTrue(manager.double(forKey: "nonExistentKey") == 0.0)
     }
-    
+
     func testStringForKey() {
         XCTAssertEqual(manager.string(forKey: "key7"), "value2")
         XCTAssertEqual(manager.string(forKey: "nonExistentKey"), "")
     }
-    
+
     func testDateForKey() {
         XCTAssertEqual(manager.date(forKey: "key6"), Date.distantFuture)
         XCTAssertEqual(manager.date(forKey: "nonExistentKey"), .distantPast)

--- a/Tests/DCSettingsTests/DCSettingsViewTests.swift
+++ b/Tests/DCSettingsTests/DCSettingsViewTests.swift
@@ -8,7 +8,7 @@ import XCTest
 import SwiftUI
 @testable import DCSettings
 
-final class DCSettingsViewTests: XCTestCase {
+@MainActor final class DCSettingsViewTests: XCTestCase {
 
     private struct CustomViewProvider: DCSettingViewProviding {
         func content(for setting: any DCSettable) -> Text? {

--- a/Tests/DCSettingsTests/DCSettingsViewTests.swift
+++ b/Tests/DCSettingsTests/DCSettingsViewTests.swift
@@ -4,11 +4,11 @@
 //  MIT license, see LICENSE file for details
 //
 
-import XCTest
+import Testing
 import SwiftUI
 @testable import DCSettings
 
-@MainActor final class DCSettingsViewTests: XCTestCase {
+@Suite @MainActor struct DCSettingsViewTests {
 
     private struct CustomViewProvider: DCSettingViewProviding {
         func content(for setting: any DCSettable) -> Text? {
@@ -16,7 +16,7 @@ import SwiftUI
         }
     }
 
-    func testDefaultInitializerUsesDefaultProviderAndPlatformListStyle() {
+    @Test func defaultInitializerUsesDefaultProviderAndPlatformListStyle() {
         #if os(macOS)
             let view: DCSettingsView<DCDefaultViewProvider, SidebarListStyle> = DCSettingsView()
         #elseif os(watchOS)
@@ -25,10 +25,10 @@ import SwiftUI
             let view: DCSettingsView<DCDefaultViewProvider, InsetGroupedListStyle> = DCSettingsView()
         #endif
 
-        XCTAssertNotNil(view)
+        #expect(!String(describing: type(of: view)).isEmpty)
     }
 
-    func testCustomProviderInitializerUsesPlatformListStyle() {
+    @Test func customProviderInitializerUsesPlatformListStyle() {
         #if os(macOS)
             let view: DCSettingsView<CustomViewProvider, SidebarListStyle> = DCSettingsView(contentProvider: CustomViewProvider())
         #elseif os(watchOS)
@@ -37,12 +37,12 @@ import SwiftUI
             let view: DCSettingsView<CustomViewProvider, InsetGroupedListStyle> = DCSettingsView(contentProvider: CustomViewProvider())
         #endif
 
-        XCTAssertNotNil(view)
+        #expect(!String(describing: type(of: view)).isEmpty)
     }
 
-    func testCustomListStyleInitializerUsesDefaultProvider() {
+    @Test func customListStyleInitializerUsesDefaultProvider() {
         let view: DCSettingsView<DCDefaultViewProvider, PlainListStyle> = DCSettingsView(listStyle: PlainListStyle())
 
-        XCTAssertNotNil(view)
+        #expect(!String(describing: type(of: view)).isEmpty)
     }
 }

--- a/Tests/DCSettingsTests/DCSettingsViewTests.swift
+++ b/Tests/DCSettingsTests/DCSettingsViewTests.swift
@@ -9,13 +9,13 @@ import SwiftUI
 @testable import DCSettings
 
 final class DCSettingsViewTests: XCTestCase {
-    
+
     private struct CustomViewProvider: DCSettingViewProviding {
         func content(for setting: any DCSettable) -> Text? {
             return nil
         }
     }
-    
+
     func testDefaultInitializerUsesDefaultProviderAndPlatformListStyle() {
         #if os(macOS)
             let view: DCSettingsView<DCDefaultViewProvider, SidebarListStyle> = DCSettingsView()
@@ -24,10 +24,10 @@ final class DCSettingsViewTests: XCTestCase {
         #else
             let view: DCSettingsView<DCDefaultViewProvider, InsetGroupedListStyle> = DCSettingsView()
         #endif
-        
+
         XCTAssertNotNil(view)
     }
-    
+
     func testCustomProviderInitializerUsesPlatformListStyle() {
         #if os(macOS)
             let view: DCSettingsView<CustomViewProvider, SidebarListStyle> = DCSettingsView(contentProvider: CustomViewProvider())
@@ -36,13 +36,13 @@ final class DCSettingsViewTests: XCTestCase {
         #else
             let view: DCSettingsView<CustomViewProvider, InsetGroupedListStyle> = DCSettingsView(contentProvider: CustomViewProvider())
         #endif
-        
+
         XCTAssertNotNil(view)
     }
-    
+
     func testCustomListStyleInitializerUsesDefaultProvider() {
         let view: DCSettingsView<DCDefaultViewProvider, PlainListStyle> = DCSettingsView(listStyle: PlainListStyle())
-        
+
         XCTAssertNotNil(view)
     }
 }

--- a/Tests/DCSettingsTests/DCSettingsViewTests.swift
+++ b/Tests/DCSettingsTests/DCSettingsViewTests.swift
@@ -1,0 +1,48 @@
+//
+//  DCSettings
+//  Copyright (c) David Caddy 2023
+//  MIT license, see LICENSE file for details
+//
+
+import XCTest
+import SwiftUI
+@testable import DCSettings
+
+final class DCSettingsViewTests: XCTestCase {
+    
+    private struct CustomViewProvider: DCSettingViewProviding {
+        func content(for setting: any DCSettable) -> Text? {
+            return nil
+        }
+    }
+    
+    func testDefaultInitializerUsesDefaultProviderAndPlatformListStyle() {
+        #if os(macOS)
+            let view: DCSettingsView<DCDefaultViewProvider, SidebarListStyle> = DCSettingsView()
+        #elseif os(watchOS)
+            let view: DCSettingsView<DCDefaultViewProvider, DefaultListStyle> = DCSettingsView()
+        #else
+            let view: DCSettingsView<DCDefaultViewProvider, InsetGroupedListStyle> = DCSettingsView()
+        #endif
+        
+        XCTAssertNotNil(view)
+    }
+    
+    func testCustomProviderInitializerUsesPlatformListStyle() {
+        #if os(macOS)
+            let view: DCSettingsView<CustomViewProvider, SidebarListStyle> = DCSettingsView(contentProvider: CustomViewProvider())
+        #elseif os(watchOS)
+            let view: DCSettingsView<CustomViewProvider, DefaultListStyle> = DCSettingsView(contentProvider: CustomViewProvider())
+        #else
+            let view: DCSettingsView<CustomViewProvider, InsetGroupedListStyle> = DCSettingsView(contentProvider: CustomViewProvider())
+        #endif
+        
+        XCTAssertNotNil(view)
+    }
+    
+    func testCustomListStyleInitializerUsesDefaultProvider() {
+        let view: DCSettingsView<DCDefaultViewProvider, PlainListStyle> = DCSettingsView(listStyle: PlainListStyle())
+        
+        XCTAssertNotNil(view)
+    }
+}

--- a/Tests/DCSettingsTests/DCStorageConvenienceTests.swift
+++ b/Tests/DCSettingsTests/DCStorageConvenienceTests.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import Combine
 @testable import DCSettings
 
-final class DCStorageConvenienceTests: XCTestCase {
+@MainActor final class DCStorageConvenienceTests: XCTestCase {
 
     private enum TestMode: String {
         case list
@@ -30,9 +30,9 @@ final class DCStorageConvenienceTests: XCTestCase {
 
     private var cancellables: Set<AnyCancellable> = []
 
-    override func tearDown() {
+    override func tearDown() async throws {
         cancellables = []
-        super.tearDown()
+        try await super.tearDown()
     }
 
     func testColorCodableRoundTrip() throws {

--- a/Tests/DCSettingsTests/DCStorageConvenienceTests.swift
+++ b/Tests/DCSettingsTests/DCStorageConvenienceTests.swift
@@ -1,0 +1,116 @@
+//
+//  DCSettings
+//  Copyright (c) David Caddy 2023
+//  MIT license, see LICENSE file for details
+//
+
+import XCTest
+import SwiftUI
+import Combine
+@testable import DCSettings
+
+final class DCStorageConvenienceTests: XCTestCase {
+    
+    private enum TestMode: String {
+        case list
+        case grid
+    }
+    
+    private struct ColorComponents: Codable {
+        let red: CGFloat
+        let green: CGFloat
+        let blue: CGFloat
+        let opacity: CGFloat
+    }
+    
+    private var cancellables: Set<AnyCancellable> = []
+    
+    override func tearDown() {
+        cancellables = []
+        super.tearDown()
+    }
+    
+    func testColorCodableRoundTrip() throws {
+        let components = ColorComponents(red: 0.25, green: 0.5, blue: 0.75, opacity: 0.6)
+        let color = Color(red: components.red, green: components.green, blue: components.blue, opacity: components.opacity)
+        
+        let encodedColor = try JSONEncoder().encode(color)
+        let decodedColor = try JSONDecoder().decode(Color.self, from: encodedColor)
+        let encodedDecodedColor = try JSONEncoder().encode(decodedColor)
+        let decodedComponents = try JSONDecoder().decode(ColorComponents.self, from: encodedDecodedColor)
+        
+        XCTAssertEqual(decodedComponents.red, components.red, accuracy: 0.001)
+        XCTAssertEqual(decodedComponents.green, components.green, accuracy: 0.001)
+        XCTAssertEqual(decodedComponents.blue, components.blue, accuracy: 0.001)
+        XCTAssertEqual(decodedComponents.opacity, components.opacity, accuracy: 0.001)
+    }
+    
+    func testUserDefaultsValuePublisherEmitsInitialAndChangedValue() {
+        let suiteName = "DCStorageConvenienceTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        let valueDidChange = expectation(description: "UserDefaults value changed")
+        var receivedValues: [String?] = []
+        
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+        
+        defaults.valuePublisher(forKey: "layout")
+            .sink { value in
+                receivedValues.append(value as? String)
+                if receivedValues.count == 2 {
+                    valueDidChange.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+        
+        defaults.set("grid", forKey: "layout")
+        
+        wait(for: [valueDidChange], timeout: 1.0)
+        XCTAssertEqual(receivedValues, [nil, "grid"])
+    }
+    
+    func testStoredValueReadsAndWritesConfiguredSetting() {
+        let manager = DCSettingsManager()
+        let backingStore = MockStore()
+        
+        manager.configure {
+            DCSettingGroup("Display", store: .custom(backingStore: backingStore)) {
+                DCSetting(key: "title", defaultValue: "Initial")
+            }
+        }
+        
+        let storedValue = DCStoredValue<String>("title", settingsManager: manager)
+        
+        XCTAssertEqual(storedValue.wrappedValue, "Initial")
+        
+        storedValue.wrappedValue = "Updated"
+        
+        XCTAssertEqual(manager.string(forKey: "title"), "Updated")
+        XCTAssertEqual(backingStore.storage["title"] as? String, "Updated")
+    }
+    
+    func testStoredRepresentedValueReadsAndWritesRawRepresentableSetting() {
+        let manager = DCSettingsManager()
+        let backingStore = MockStore()
+        
+        manager.configure {
+            DCSettingGroup("Display", store: .custom(backingStore: backingStore)) {
+                DCSetting(key: "mode", defaultValue: TestMode.list.rawValue)
+            }
+        }
+        
+        let storedValue = DCStoredRepresentedValue<TestMode>("mode", settingsManager: manager)
+        
+        XCTAssertEqual(storedValue.wrappedValue, .list)
+        
+        storedValue.wrappedValue = .grid
+        
+        XCTAssertEqual(manager.string(forKey: "mode"), TestMode.grid.rawValue)
+        XCTAssertEqual(backingStore.storage["mode"] as? String, TestMode.grid.rawValue)
+        
+        storedValue.wrappedValue = nil
+        
+        XCTAssertEqual(manager.string(forKey: "mode"), TestMode.grid.rawValue)
+    }
+}

--- a/Tests/DCSettingsTests/DCStorageConvenienceTests.swift
+++ b/Tests/DCSettingsTests/DCStorageConvenienceTests.swift
@@ -4,12 +4,12 @@
 //  MIT license, see LICENSE file for details
 //
 
-import XCTest
+import Testing
 import SwiftUI
 import Combine
 @testable import DCSettings
 
-@MainActor final class DCStorageConvenienceTests: XCTestCase {
+@Suite @MainActor struct DCStorageConvenienceTests {
 
     private enum TestMode: String {
         case list
@@ -28,14 +28,7 @@ import Combine
         let columns: Int
     }
 
-    private var cancellables: Set<AnyCancellable> = []
-
-    override func tearDown() async throws {
-        cancellables = []
-        try await super.tearDown()
-    }
-
-    func testColorCodableRoundTrip() throws {
+    @Test func colorCodableRoundTrip() throws {
         let components = ColorComponents(red: 0.25, green: 0.5, blue: 0.75, opacity: 0.6)
         let color = Color(red: components.red, green: components.green, blue: components.blue, opacity: components.opacity)
 
@@ -44,17 +37,17 @@ import Combine
         let encodedDecodedColor = try JSONEncoder().encode(decodedColor)
         let decodedComponents = try JSONDecoder().decode(ColorComponents.self, from: encodedDecodedColor)
 
-        XCTAssertEqual(decodedComponents.red, components.red, accuracy: 0.001)
-        XCTAssertEqual(decodedComponents.green, components.green, accuracy: 0.001)
-        XCTAssertEqual(decodedComponents.blue, components.blue, accuracy: 0.001)
-        XCTAssertEqual(decodedComponents.opacity, components.opacity, accuracy: 0.001)
+        #expect(abs(decodedComponents.red - components.red) <= 0.001)
+        #expect(abs(decodedComponents.green - components.green) <= 0.001)
+        #expect(abs(decodedComponents.blue - components.blue) <= 0.001)
+        #expect(abs(decodedComponents.opacity - components.opacity) <= 0.001)
     }
 
-    func testUserDefaultsValuePublisherEmitsInitialAndChangedValue() {
+    @Test func userDefaultsValuePublisherEmitsInitialAndChangedValue() async throws {
         let suiteName = "DCStorageConvenienceTests.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        let valueDidChange = expectation(description: "UserDefaults value changed")
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
         var receivedValues: [String?] = []
+        var cancellables: Set<AnyCancellable> = []
 
         defer {
             defaults.removePersistentDomain(forName: suiteName)
@@ -63,24 +56,20 @@ import Combine
         defaults.valuePublisher(forKey: "layout")
             .sink { value in
                 receivedValues.append(value as? String)
-                if receivedValues.count == 2 {
-                    valueDidChange.fulfill()
-                }
             }
             .store(in: &cancellables)
 
         defaults.set("grid", forKey: "layout")
 
-        wait(for: [valueDidChange], timeout: 1.0)
-        XCTAssertEqual(receivedValues, [nil, "grid"])
+        #expect(await waitUntil { receivedValues.count == 2 })
+        #expect(receivedValues == [nil, "grid"])
     }
 
-    func testUserDefaultsValuePublisherDoesNotEmitDuplicateValueForUnrelatedChange() {
+    @Test func userDefaultsValuePublisherDoesNotEmitDuplicateValueForUnrelatedChange() async throws {
         let suiteName = "DCStorageConvenienceTests.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        let unrelatedChangeDidNotEmit = expectation(description: "Unrelated UserDefaults change did not emit")
-        unrelatedChangeDidNotEmit.isInverted = true
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
         var receivedValues: [String?] = []
+        var cancellables: Set<AnyCancellable> = []
 
         defer {
             defaults.removePersistentDomain(forName: suiteName)
@@ -91,26 +80,22 @@ import Combine
         defaults.valuePublisher(forKey: "layout")
             .sink { value in
                 receivedValues.append(value as? String)
-                if receivedValues.count > 1 {
-                    unrelatedChangeDidNotEmit.fulfill()
-                }
             }
             .store(in: &cancellables)
 
         defaults.set("dark", forKey: "theme")
 
-        wait(for: [unrelatedChangeDidNotEmit], timeout: 0.2)
-        XCTAssertEqual(receivedValues, ["list"])
+        try? await Task.sleep(for: .milliseconds(200))
+        #expect(receivedValues == ["list"])
     }
 
-    func testUserDefaultsValuePublisherKeepsSuiteValuesIsolated() {
+    @Test func userDefaultsValuePublisherKeepsSuiteValuesIsolated() async throws {
         let observedSuiteName = "DCStorageConvenienceTests.observed.\(UUID().uuidString)"
         let unrelatedSuiteName = "DCStorageConvenienceTests.unrelated.\(UUID().uuidString)"
-        let observedDefaults = UserDefaults(suiteName: observedSuiteName)!
-        let unrelatedDefaults = UserDefaults(suiteName: unrelatedSuiteName)!
-        let unrelatedSuiteDidNotEmit = expectation(description: "Unrelated UserDefaults suite change did not emit")
-        unrelatedSuiteDidNotEmit.isInverted = true
+        let observedDefaults = try #require(UserDefaults(suiteName: observedSuiteName))
+        let unrelatedDefaults = try #require(UserDefaults(suiteName: unrelatedSuiteName))
         var receivedValues: [String?] = []
+        var cancellables: Set<AnyCancellable> = []
 
         defer {
             observedDefaults.removePersistentDomain(forName: observedSuiteName)
@@ -122,25 +107,22 @@ import Combine
         observedDefaults.valuePublisher(forKey: "layout")
             .sink { value in
                 receivedValues.append(value as? String)
-                if receivedValues.count > 1 {
-                    unrelatedSuiteDidNotEmit.fulfill()
-                }
             }
             .store(in: &cancellables)
 
         unrelatedDefaults.set("grid", forKey: "layout")
 
-        wait(for: [unrelatedSuiteDidNotEmit], timeout: 0.2)
-        XCTAssertEqual(receivedValues, ["list"])
+        try? await Task.sleep(for: .milliseconds(200))
+        #expect(receivedValues == ["list"])
     }
 
-    func testUserDefaultsSettingStoreTypedValuePublisherEmitsInitialAndChangedValue() {
+    @Test func userDefaultsSettingStoreTypedValuePublisherEmitsInitialAndChangedValue() async throws {
         let suiteName = "DCStorageConvenienceTests.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
         let store = DCSettingStore.userDefaults(suiteName: suiteName)
         let key = "layout"
-        let valueDidChange = expectation(description: "Typed UserDefaults setting store value changed")
         var receivedValues: [String?] = []
+        var cancellables: Set<AnyCancellable> = []
 
         defer {
             defaults.removePersistentDomain(forName: suiteName)
@@ -151,52 +133,46 @@ import Combine
         store.valuePublisher(forKey: key, as: String.self)
             .sink { value in
                 receivedValues.append(value)
-                if receivedValues.count == 2 {
-                    valueDidChange.fulfill()
-                }
             }
             .store(in: &cancellables)
 
         store.set("grid", forKey: key)
 
-        wait(for: [valueDidChange], timeout: 1.0)
-        XCTAssertEqual(receivedValues, ["list", "grid"])
+        #expect(await waitUntil { receivedValues.count == 2 })
+        #expect(receivedValues == ["list", "grid"])
     }
 
-    func testUserDefaultsSettingStoreTypedValuePublisherDecodesCodableValues() {
+    @Test func userDefaultsSettingStoreTypedValuePublisherDecodesCodableValues() async throws {
         let suiteName = "DCStorageConvenienceTests.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
         let store = DCSettingStore.userDefaults(suiteName: suiteName)
         let key = "layout"
         let firstValue = StoredLayout(name: "list", columns: 1)
         let secondValue = StoredLayout(name: "grid", columns: 3)
-        let valueDidChange = expectation(description: "Typed UserDefaults setting store Codable value changed")
         var receivedValues: [StoredLayout?] = []
+        var cancellables: Set<AnyCancellable> = []
 
         defer {
             defaults.removePersistentDomain(forName: suiteName)
         }
 
-        XCTAssertTrue(store.set(firstValue, forKey: key))
+        #expect(store.set(firstValue, forKey: key))
 
         store.valuePublisher(forKey: key, as: StoredLayout.self)
             .sink { value in
                 receivedValues.append(value)
-                if receivedValues.count == 2 {
-                    valueDidChange.fulfill()
-                }
             }
             .store(in: &cancellables)
 
-        XCTAssertTrue(store.set(secondValue, forKey: key))
+        #expect(store.set(secondValue, forKey: key))
 
-        wait(for: [valueDidChange], timeout: 1.0)
-        XCTAssertEqual(receivedValues, [firstValue, secondValue])
+        #expect(await waitUntil { receivedValues.count == 2 })
+        #expect(receivedValues == [firstValue, secondValue])
     }
 
-    func testSettingStoreSetReturnsTrueWhenClearingCodableValue() {
+    @Test func settingStoreSetReturnsTrueWhenClearingCodableValue() throws {
         let suiteName = "DCStorageConvenienceTests.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
         let store = DCSettingStore.userDefaults(suiteName: suiteName)
         let key = "layout"
         let value = StoredLayout(name: "list", columns: 1)
@@ -205,25 +181,24 @@ import Combine
             defaults.removePersistentDomain(forName: suiteName)
         }
 
-        XCTAssertTrue(store.set(value, forKey: key))
-        XCTAssertEqual(store.object(forKey: key), value)
+        #expect(store.set(value, forKey: key))
+        #expect(store.object(forKey: key) == value)
 
-        XCTAssertTrue(store.set(nil as StoredLayout?, forKey: key))
-        XCTAssertNil(store.object(forKey: key) as StoredLayout?)
+        #expect(store.set(nil as StoredLayout?, forKey: key))
+        #expect((store.object(forKey: key) as StoredLayout?) == nil)
     }
 
-    func testUbiquitousValuePublisherIgnoresUnrelatedChangedKeysNotification() throws {
+    @Test func ubiquitousValuePublisherIgnoresUnrelatedChangedKeysNotification() async {
         #if os(watchOS)
-            guard #available(watchOS 9.0, *) else {
-                throw XCTSkip("NSUbiquitousKeyValueStore DCKeyValueStore conformance requires watchOS 9 or newer.")
+            if #unavailable(watchOS 9.0) {
+                return
             }
         #endif
 
         let store = NSUbiquitousKeyValueStore.default
         let key = "DCStorageConvenienceTests.\(UUID().uuidString).layout"
-        let unrelatedNotificationDidNotEmit = expectation(description: "Unrelated ubiquitous notification did not emit")
-        unrelatedNotificationDidNotEmit.isInverted = true
         var receivedValueCount = 0
+        var cancellables: Set<AnyCancellable> = []
 
         defer {
             store.removeObject(forKey: key)
@@ -232,9 +207,6 @@ import Combine
         store.valuePublisher(forKey: key)
             .sink { _ in
                 receivedValueCount += 1
-                if receivedValueCount > 1 {
-                    unrelatedNotificationDidNotEmit.fulfill()
-                }
             }
             .store(in: &cancellables)
 
@@ -244,11 +216,11 @@ import Combine
             userInfo: [NSUbiquitousKeyValueStoreChangedKeysKey: ["unrelated"]]
         )
 
-        wait(for: [unrelatedNotificationDidNotEmit], timeout: 0.2)
-        XCTAssertEqual(receivedValueCount, 1)
+        try? await Task.sleep(for: .milliseconds(200))
+        #expect(receivedValueCount == 1)
     }
 
-    func testStoredValueReadsAndWritesConfiguredSetting() {
+    @Test func storedValueReadsAndWritesConfiguredSetting() {
         let manager = DCSettingsManager()
         let backingStore = MockStore()
 
@@ -260,15 +232,15 @@ import Combine
 
         let storedValue = DCStoredValue<String>("title", settingsManager: manager)
 
-        XCTAssertEqual(storedValue.wrappedValue, "Initial")
+        #expect(storedValue.wrappedValue == "Initial")
 
         storedValue.wrappedValue = "Updated"
 
-        XCTAssertEqual(manager.string(forKey: "title"), "Updated")
-        XCTAssertEqual(backingStore.storage["title"] as? String, "Updated")
+        #expect(manager.string(forKey: "title") == "Updated")
+        #expect(backingStore.storage["title"] as? String == "Updated")
     }
 
-    func testStoredRepresentedValueReadsAndWritesRawRepresentableSetting() {
+    @Test func storedRepresentedValueReadsAndWritesRawRepresentableSetting() {
         let manager = DCSettingsManager()
         let backingStore = MockStore()
 
@@ -280,15 +252,15 @@ import Combine
 
         let storedValue = DCStoredRepresentedValue<TestMode>("mode", settingsManager: manager)
 
-        XCTAssertEqual(storedValue.wrappedValue, .list)
+        #expect(storedValue.wrappedValue == .list)
 
         storedValue.wrappedValue = .grid
 
-        XCTAssertEqual(manager.string(forKey: "mode"), TestMode.grid.rawValue)
-        XCTAssertEqual(backingStore.storage["mode"] as? String, TestMode.grid.rawValue)
+        #expect(manager.string(forKey: "mode") == TestMode.grid.rawValue)
+        #expect(backingStore.storage["mode"] as? String == TestMode.grid.rawValue)
 
         storedValue.wrappedValue = nil
 
-        XCTAssertEqual(manager.string(forKey: "mode"), TestMode.grid.rawValue)
+        #expect(manager.string(forKey: "mode") == TestMode.grid.rawValue)
     }
 }

--- a/Tests/DCSettingsTests/DCStorageConvenienceTests.swift
+++ b/Tests/DCSettingsTests/DCStorageConvenienceTests.swift
@@ -28,13 +28,18 @@ import Combine
         let columns: Int
     }
 
-    @Test func colorCodableRoundTrip() throws {
+    @Test func colorSettingStoreRoundTrip() throws {
         let components = ColorComponents(red: 0.25, green: 0.5, blue: 0.75, opacity: 0.6)
         let color = Color(red: components.red, green: components.green, blue: components.blue, opacity: components.opacity)
+        let backingStore = MockStore()
+        let store = DCSettingStore.custom(backingStore: backingStore)
+        let key = "color"
 
-        let encodedColor = try JSONEncoder().encode(color)
-        let decodedColor = try JSONDecoder().decode(Color.self, from: encodedColor)
-        let encodedDecodedColor = try JSONEncoder().encode(decodedColor)
+        #expect(store.set(color, forKey: key))
+        #expect(backingStore.storage[key] is Data)
+
+        let decodedColor = try #require(store.object(forKey: key) as Color?)
+        let encodedDecodedColor = try decodedColor.dcSettingsEncodedData()
         let decodedComponents = try JSONDecoder().decode(ColorComponents.self, from: encodedDecodedColor)
 
         #expect(abs(decodedComponents.red - components.red) <= 0.001)

--- a/Tests/DCSettingsTests/DCStorageConvenienceTests.swift
+++ b/Tests/DCSettingsTests/DCStorageConvenienceTests.swift
@@ -70,6 +70,64 @@ final class DCStorageConvenienceTests: XCTestCase {
         XCTAssertEqual(receivedValues, [nil, "grid"])
     }
     
+    func testUserDefaultsValuePublisherDoesNotEmitDuplicateValueForUnrelatedChange() {
+        let suiteName = "DCStorageConvenienceTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        let unrelatedChangeDidNotEmit = expectation(description: "Unrelated UserDefaults change did not emit")
+        unrelatedChangeDidNotEmit.isInverted = true
+        var receivedValues: [String?] = []
+        
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+        
+        defaults.set("list", forKey: "layout")
+        
+        defaults.valuePublisher(forKey: "layout")
+            .sink { value in
+                receivedValues.append(value as? String)
+                if receivedValues.count > 1 {
+                    unrelatedChangeDidNotEmit.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+        
+        defaults.set("dark", forKey: "theme")
+        
+        wait(for: [unrelatedChangeDidNotEmit], timeout: 0.2)
+        XCTAssertEqual(receivedValues, ["list"])
+    }
+    
+    func testUbiquitousValuePublisherIgnoresUnrelatedChangedKeysNotification() {
+        let store = NSUbiquitousKeyValueStore.default
+        let key = "DCStorageConvenienceTests.\(UUID().uuidString).layout"
+        let unrelatedNotificationDidNotEmit = expectation(description: "Unrelated ubiquitous notification did not emit")
+        unrelatedNotificationDidNotEmit.isInverted = true
+        var receivedValueCount = 0
+        
+        defer {
+            store.removeObject(forKey: key)
+        }
+        
+        store.valuePublisher(forKey: key)
+            .sink { _ in
+                receivedValueCount += 1
+                if receivedValueCount > 1 {
+                    unrelatedNotificationDidNotEmit.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+        
+        NotificationCenter.default.post(
+            name: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
+            object: store,
+            userInfo: [NSUbiquitousKeyValueStoreChangedKeysKey: ["unrelated"]]
+        )
+        
+        wait(for: [unrelatedNotificationDidNotEmit], timeout: 0.2)
+        XCTAssertEqual(receivedValueCount, 1)
+    }
+    
     func testStoredValueReadsAndWritesConfiguredSetting() {
         let manager = DCSettingsManager()
         let backingStore = MockStore()

--- a/Tests/DCSettingsTests/DCStorageConvenienceTests.swift
+++ b/Tests/DCSettingsTests/DCStorageConvenienceTests.swift
@@ -10,51 +10,56 @@ import Combine
 @testable import DCSettings
 
 final class DCStorageConvenienceTests: XCTestCase {
-    
+
     private enum TestMode: String {
         case list
         case grid
     }
-    
+
     private struct ColorComponents: Codable {
         let red: CGFloat
         let green: CGFloat
         let blue: CGFloat
         let opacity: CGFloat
     }
-    
+
+    private struct StoredLayout: Codable, Equatable {
+        let name: String
+        let columns: Int
+    }
+
     private var cancellables: Set<AnyCancellable> = []
-    
+
     override func tearDown() {
         cancellables = []
         super.tearDown()
     }
-    
+
     func testColorCodableRoundTrip() throws {
         let components = ColorComponents(red: 0.25, green: 0.5, blue: 0.75, opacity: 0.6)
         let color = Color(red: components.red, green: components.green, blue: components.blue, opacity: components.opacity)
-        
+
         let encodedColor = try JSONEncoder().encode(color)
         let decodedColor = try JSONDecoder().decode(Color.self, from: encodedColor)
         let encodedDecodedColor = try JSONEncoder().encode(decodedColor)
         let decodedComponents = try JSONDecoder().decode(ColorComponents.self, from: encodedDecodedColor)
-        
+
         XCTAssertEqual(decodedComponents.red, components.red, accuracy: 0.001)
         XCTAssertEqual(decodedComponents.green, components.green, accuracy: 0.001)
         XCTAssertEqual(decodedComponents.blue, components.blue, accuracy: 0.001)
         XCTAssertEqual(decodedComponents.opacity, components.opacity, accuracy: 0.001)
     }
-    
+
     func testUserDefaultsValuePublisherEmitsInitialAndChangedValue() {
         let suiteName = "DCStorageConvenienceTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         let valueDidChange = expectation(description: "UserDefaults value changed")
         var receivedValues: [String?] = []
-        
+
         defer {
             defaults.removePersistentDomain(forName: suiteName)
         }
-        
+
         defaults.valuePublisher(forKey: "layout")
             .sink { value in
                 receivedValues.append(value as? String)
@@ -63,26 +68,26 @@ final class DCStorageConvenienceTests: XCTestCase {
                 }
             }
             .store(in: &cancellables)
-        
+
         defaults.set("grid", forKey: "layout")
-        
+
         wait(for: [valueDidChange], timeout: 1.0)
         XCTAssertEqual(receivedValues, [nil, "grid"])
     }
-    
+
     func testUserDefaultsValuePublisherDoesNotEmitDuplicateValueForUnrelatedChange() {
         let suiteName = "DCStorageConvenienceTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         let unrelatedChangeDidNotEmit = expectation(description: "Unrelated UserDefaults change did not emit")
         unrelatedChangeDidNotEmit.isInverted = true
         var receivedValues: [String?] = []
-        
+
         defer {
             defaults.removePersistentDomain(forName: suiteName)
         }
-        
+
         defaults.set("list", forKey: "layout")
-        
+
         defaults.valuePublisher(forKey: "layout")
             .sink { value in
                 receivedValues.append(value as? String)
@@ -91,24 +96,139 @@ final class DCStorageConvenienceTests: XCTestCase {
                 }
             }
             .store(in: &cancellables)
-        
+
         defaults.set("dark", forKey: "theme")
-        
+
         wait(for: [unrelatedChangeDidNotEmit], timeout: 0.2)
         XCTAssertEqual(receivedValues, ["list"])
     }
-    
-    func testUbiquitousValuePublisherIgnoresUnrelatedChangedKeysNotification() {
+
+    func testUserDefaultsValuePublisherKeepsSuiteValuesIsolated() {
+        let observedSuiteName = "DCStorageConvenienceTests.observed.\(UUID().uuidString)"
+        let unrelatedSuiteName = "DCStorageConvenienceTests.unrelated.\(UUID().uuidString)"
+        let observedDefaults = UserDefaults(suiteName: observedSuiteName)!
+        let unrelatedDefaults = UserDefaults(suiteName: unrelatedSuiteName)!
+        let unrelatedSuiteDidNotEmit = expectation(description: "Unrelated UserDefaults suite change did not emit")
+        unrelatedSuiteDidNotEmit.isInverted = true
+        var receivedValues: [String?] = []
+
+        defer {
+            observedDefaults.removePersistentDomain(forName: observedSuiteName)
+            unrelatedDefaults.removePersistentDomain(forName: unrelatedSuiteName)
+        }
+
+        observedDefaults.set("list", forKey: "layout")
+
+        observedDefaults.valuePublisher(forKey: "layout")
+            .sink { value in
+                receivedValues.append(value as? String)
+                if receivedValues.count > 1 {
+                    unrelatedSuiteDidNotEmit.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        unrelatedDefaults.set("grid", forKey: "layout")
+
+        wait(for: [unrelatedSuiteDidNotEmit], timeout: 0.2)
+        XCTAssertEqual(receivedValues, ["list"])
+    }
+
+    func testUserDefaultsSettingStoreTypedValuePublisherEmitsInitialAndChangedValue() {
+        let suiteName = "DCStorageConvenienceTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        let store = DCSettingStore.userDefaults(suiteName: suiteName)
+        let key = "layout"
+        let valueDidChange = expectation(description: "Typed UserDefaults setting store value changed")
+        var receivedValues: [String?] = []
+
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        defaults.set("list", forKey: key)
+
+        store.valuePublisher(forKey: key, as: String.self)
+            .sink { value in
+                receivedValues.append(value)
+                if receivedValues.count == 2 {
+                    valueDidChange.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        store.set("grid", forKey: key)
+
+        wait(for: [valueDidChange], timeout: 1.0)
+        XCTAssertEqual(receivedValues, ["list", "grid"])
+    }
+
+    func testUserDefaultsSettingStoreTypedValuePublisherDecodesCodableValues() {
+        let suiteName = "DCStorageConvenienceTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        let store = DCSettingStore.userDefaults(suiteName: suiteName)
+        let key = "layout"
+        let firstValue = StoredLayout(name: "list", columns: 1)
+        let secondValue = StoredLayout(name: "grid", columns: 3)
+        let valueDidChange = expectation(description: "Typed UserDefaults setting store Codable value changed")
+        var receivedValues: [StoredLayout?] = []
+
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        XCTAssertTrue(store.set(firstValue, forKey: key))
+
+        store.valuePublisher(forKey: key, as: StoredLayout.self)
+            .sink { value in
+                receivedValues.append(value)
+                if receivedValues.count == 2 {
+                    valueDidChange.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        XCTAssertTrue(store.set(secondValue, forKey: key))
+
+        wait(for: [valueDidChange], timeout: 1.0)
+        XCTAssertEqual(receivedValues, [firstValue, secondValue])
+    }
+
+    func testSettingStoreSetReturnsTrueWhenClearingCodableValue() {
+        let suiteName = "DCStorageConvenienceTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        let store = DCSettingStore.userDefaults(suiteName: suiteName)
+        let key = "layout"
+        let value = StoredLayout(name: "list", columns: 1)
+
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        XCTAssertTrue(store.set(value, forKey: key))
+        XCTAssertEqual(store.object(forKey: key), value)
+
+        XCTAssertTrue(store.set(nil as StoredLayout?, forKey: key))
+        XCTAssertNil(store.object(forKey: key) as StoredLayout?)
+    }
+
+    func testUbiquitousValuePublisherIgnoresUnrelatedChangedKeysNotification() throws {
+        #if os(watchOS)
+            guard #available(watchOS 9.0, *) else {
+                throw XCTSkip("NSUbiquitousKeyValueStore DCKeyValueStore conformance requires watchOS 9 or newer.")
+            }
+        #endif
+
         let store = NSUbiquitousKeyValueStore.default
         let key = "DCStorageConvenienceTests.\(UUID().uuidString).layout"
         let unrelatedNotificationDidNotEmit = expectation(description: "Unrelated ubiquitous notification did not emit")
         unrelatedNotificationDidNotEmit.isInverted = true
         var receivedValueCount = 0
-        
+
         defer {
             store.removeObject(forKey: key)
         }
-        
+
         store.valuePublisher(forKey: key)
             .sink { _ in
                 receivedValueCount += 1
@@ -117,58 +237,58 @@ final class DCStorageConvenienceTests: XCTestCase {
                 }
             }
             .store(in: &cancellables)
-        
+
         NotificationCenter.default.post(
             name: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
             object: store,
             userInfo: [NSUbiquitousKeyValueStoreChangedKeysKey: ["unrelated"]]
         )
-        
+
         wait(for: [unrelatedNotificationDidNotEmit], timeout: 0.2)
         XCTAssertEqual(receivedValueCount, 1)
     }
-    
+
     func testStoredValueReadsAndWritesConfiguredSetting() {
         let manager = DCSettingsManager()
         let backingStore = MockStore()
-        
+
         manager.configure {
             DCSettingGroup("Display", store: .custom(backingStore: backingStore)) {
                 DCSetting(key: "title", defaultValue: "Initial")
             }
         }
-        
+
         let storedValue = DCStoredValue<String>("title", settingsManager: manager)
-        
+
         XCTAssertEqual(storedValue.wrappedValue, "Initial")
-        
+
         storedValue.wrappedValue = "Updated"
-        
+
         XCTAssertEqual(manager.string(forKey: "title"), "Updated")
         XCTAssertEqual(backingStore.storage["title"] as? String, "Updated")
     }
-    
+
     func testStoredRepresentedValueReadsAndWritesRawRepresentableSetting() {
         let manager = DCSettingsManager()
         let backingStore = MockStore()
-        
+
         manager.configure {
             DCSettingGroup("Display", store: .custom(backingStore: backingStore)) {
                 DCSetting(key: "mode", defaultValue: TestMode.list.rawValue)
             }
         }
-        
+
         let storedValue = DCStoredRepresentedValue<TestMode>("mode", settingsManager: manager)
-        
+
         XCTAssertEqual(storedValue.wrappedValue, .list)
-        
+
         storedValue.wrappedValue = .grid
-        
+
         XCTAssertEqual(manager.string(forKey: "mode"), TestMode.grid.rawValue)
         XCTAssertEqual(backingStore.storage["mode"] as? String, TestMode.grid.rawValue)
-        
+
         storedValue.wrappedValue = nil
-        
+
         XCTAssertEqual(manager.string(forKey: "mode"), TestMode.grid.rawValue)
     }
 }

--- a/Tests/DCSettingsTests/DCValueBoundsTests.swift
+++ b/Tests/DCSettingsTests/DCValueBoundsTests.swift
@@ -4,29 +4,27 @@
 //  MIT license, see LICENSE file for details
 //
 
-import XCTest
+import Testing
 @testable import DCSettings
 
-final class DCValueBoundsTests: XCTestCase {
+@Suite struct DCValueBoundsTests {
 
-    func testEquatable() {
+    @Test func equatable() {
         let bounds1 = DCValueBounds(lowerBound: 0, upperBound: 10)
         let bounds2 = DCValueBounds(lowerBound: 0, upperBound: 10)
         let bounds3 = DCValueBounds(lowerBound: 5, upperBound: 15)
 
-        XCTAssertEqual(bounds1, bounds2)
-        XCTAssertNotEqual(bounds1, bounds3)
+        #expect(bounds1 == bounds2)
+        #expect(bounds1 != bounds3)
     }
 
-    func testLowerBound() {
+    @Test func lowerBound() {
         let bounds = DCValueBounds(lowerBound: 0, upperBound: 10)
-        XCTAssertEqual(bounds.lowerBound, 0)
+        #expect(bounds.lowerBound == 0)
     }
 
-    func testUpperBound() {
+    @Test func upperBound() {
         let bounds = DCValueBounds(lowerBound: 0, upperBound: 10)
-        XCTAssertEqual(bounds.upperBound, 10)
+        #expect(bounds.upperBound == 10)
     }
-
 }
-

--- a/Tests/DCSettingsTests/DCValueBoundsTests.swift
+++ b/Tests/DCSettingsTests/DCValueBoundsTests.swift
@@ -13,16 +13,16 @@ final class DCValueBoundsTests: XCTestCase {
         let bounds1 = DCValueBounds(lowerBound: 0, upperBound: 10)
         let bounds2 = DCValueBounds(lowerBound: 0, upperBound: 10)
         let bounds3 = DCValueBounds(lowerBound: 5, upperBound: 15)
-        
+
         XCTAssertEqual(bounds1, bounds2)
         XCTAssertNotEqual(bounds1, bounds3)
     }
-    
+
     func testLowerBound() {
         let bounds = DCValueBounds(lowerBound: 0, upperBound: 10)
         XCTAssertEqual(bounds.lowerBound, 0)
     }
-    
+
     func testUpperBound() {
         let bounds = DCValueBounds(lowerBound: 0, upperBound: 10)
         XCTAssertEqual(bounds.upperBound, 10)

--- a/Tests/DCSettingsTests/Mocks/MockStore.swift
+++ b/Tests/DCSettingsTests/Mocks/MockStore.swift
@@ -10,13 +10,19 @@ import DCSettings
 
 class MockStore: DCKeyValueStore {
     var storage: [String: Any] = [:]
+    private var setCounts: [String: Int] = [:]
     private let subject = PassthroughSubject<(String, Any?), Never>()
+
+    func setCallCount(forKey key: String) -> Int {
+        setCounts[key, default: 0]
+    }
 
     func valuePublisher(forKey key: String) -> AnyPublisher<Any?, Never> {
         return subject.filter { $0.0 == key }.map { $0.1 }.eraseToAnyPublisher()
     }
 
     func set(_ value: Any?, forKey defaultName: String) {
+        setCounts[defaultName, default: 0] += 1
         storage[defaultName] = value
         subject.send((defaultName, value))
     }
@@ -26,6 +32,7 @@ class MockStore: DCKeyValueStore {
     }
 
     func set(_ value: Bool, forKey defaultName: String) {
+        setCounts[defaultName, default: 0] += 1
         storage[defaultName] = value
         subject.send((defaultName, value))
     }
@@ -35,6 +42,7 @@ class MockStore: DCKeyValueStore {
     }
 
     func set(_ value: Int, forKey defaultName: String) {
+        setCounts[defaultName, default: 0] += 1
         storage[defaultName] = value
         subject.send((defaultName, value))
     }
@@ -44,6 +52,7 @@ class MockStore: DCKeyValueStore {
     }
 
     func set(_ value: Double, forKey defaultName: String) {
+        setCounts[defaultName, default: 0] += 1
         storage[defaultName] = value
         subject.send((defaultName, value))
     }

--- a/Tests/DCSettingsTests/Mocks/MockStore.swift
+++ b/Tests/DCSettingsTests/Mocks/MockStore.swift
@@ -11,51 +11,51 @@ import DCSettings
 class MockStore: DCKeyValueStore {
     var storage: [String: Any] = [:]
     private let subject = PassthroughSubject<(String, Any?), Never>()
-    
+
     func valuePublisher(forKey key: String) -> AnyPublisher<Any?, Never> {
         return subject.filter { $0.0 == key }.map { $0.1 }.eraseToAnyPublisher()
     }
-    
+
     func set(_ value: Any?, forKey defaultName: String) {
         storage[defaultName] = value
         subject.send((defaultName, value))
     }
-    
+
     func object(forKey defaultName: String) -> Any? {
         return storage[defaultName]
     }
-    
+
     func set(_ value: Bool, forKey defaultName: String) {
         storage[defaultName] = value
         subject.send((defaultName, value))
     }
-    
+
     func bool(forKey defaultName: String) -> Bool {
         return storage[defaultName] as? Bool ?? false
     }
-    
+
     func set(_ value: Int, forKey defaultName: String) {
         storage[defaultName] = value
         subject.send((defaultName, value))
     }
-    
+
     func integer(forKey defaultName: String) -> Int {
         return storage[defaultName] as? Int ?? 0
     }
-    
+
     func set(_ value: Double, forKey defaultName: String) {
         storage[defaultName] = value
         subject.send((defaultName, value))
     }
-    
+
     func double(forKey defaultName: String) -> Double {
         return storage[defaultName] as? Double ?? 0.0
     }
-    
+
     func string(forKey defaultName: String) -> String? {
         return storage[defaultName] as? String
     }
-    
+
     func synchronize() -> Bool {
         return true
     }

--- a/Tests/DCSettingsTests/StringExtendedTests.swift
+++ b/Tests/DCSettingsTests/StringExtendedTests.swift
@@ -18,6 +18,10 @@ final class StringExtendedTests: XCTestCase {
     }
     
     func testSentenceFormattedFormatsAcronymCamelCaseInput() {
-        XCTAssertEqual("URLScheme".sentenceFormatted, "Urlscheme")
+        XCTAssertEqual("URLScheme".sentenceFormatted, "URL scheme")
+    }
+    
+    func testSentenceFormattedPreservesAcronymsAfterFirstWord() {
+        XCTAssertEqual("callbackURLScheme".sentenceFormatted, "Callback URL scheme")
     }
 }

--- a/Tests/DCSettingsTests/StringExtendedTests.swift
+++ b/Tests/DCSettingsTests/StringExtendedTests.swift
@@ -1,0 +1,23 @@
+//
+//  DCSettings
+//  Copyright (c) David Caddy 2023
+//  MIT license, see LICENSE file for details
+//
+
+import XCTest
+@testable import DCSettings
+
+final class StringExtendedTests: XCTestCase {
+    
+    func testSentenceCapitalizedLowercasesRemainingCharacters() {
+        XCTAssertEqual("hELLO WORLD".sentenceCapitalized, "Hello world")
+    }
+    
+    func testSentenceFormattedReplacesUnderscoresAndCamelCase() {
+        XCTAssertEqual("great_userSetting2".sentenceFormatted, "Great user setting 2")
+    }
+    
+    func testSentenceFormattedTrimsLeadingWhitespaceFromAcronyms() {
+        XCTAssertEqual("URLScheme".sentenceFormatted, "Urlscheme")
+    }
+}

--- a/Tests/DCSettingsTests/StringExtendedTests.swift
+++ b/Tests/DCSettingsTests/StringExtendedTests.swift
@@ -8,19 +8,19 @@ import XCTest
 @testable import DCSettings
 
 final class StringExtendedTests: XCTestCase {
-    
+
     func testSentenceCapitalizedLowercasesRemainingCharacters() {
         XCTAssertEqual("hELLO WORLD".sentenceCapitalized, "Hello world")
     }
-    
+
     func testSentenceFormattedReplacesUnderscoresAndCamelCase() {
         XCTAssertEqual("great_userSetting2".sentenceFormatted, "Great user setting 2")
     }
-    
+
     func testSentenceFormattedFormatsAcronymCamelCaseInput() {
         XCTAssertEqual("URLScheme".sentenceFormatted, "URL scheme")
     }
-    
+
     func testSentenceFormattedPreservesAcronymsAfterFirstWord() {
         XCTAssertEqual("callbackURLScheme".sentenceFormatted, "Callback URL scheme")
     }

--- a/Tests/DCSettingsTests/StringExtendedTests.swift
+++ b/Tests/DCSettingsTests/StringExtendedTests.swift
@@ -4,24 +4,24 @@
 //  MIT license, see LICENSE file for details
 //
 
-import XCTest
+import Testing
 @testable import DCSettings
 
-final class StringExtendedTests: XCTestCase {
+@Suite struct StringExtendedTests {
 
-    func testSentenceCapitalizedLowercasesRemainingCharacters() {
-        XCTAssertEqual("hELLO WORLD".sentenceCapitalized, "Hello world")
+    @Test func sentenceCapitalizedLowercasesRemainingCharacters() {
+        #expect("hELLO WORLD".sentenceCapitalized == "Hello world")
     }
 
-    func testSentenceFormattedReplacesUnderscoresAndCamelCase() {
-        XCTAssertEqual("great_userSetting2".sentenceFormatted, "Great user setting 2")
+    @Test func sentenceFormattedReplacesUnderscoresAndCamelCase() {
+        #expect("great_userSetting2".sentenceFormatted == "Great user setting 2")
     }
 
-    func testSentenceFormattedFormatsAcronymCamelCaseInput() {
-        XCTAssertEqual("URLScheme".sentenceFormatted, "URL scheme")
+    @Test func sentenceFormattedFormatsAcronymCamelCaseInput() {
+        #expect("URLScheme".sentenceFormatted == "URL scheme")
     }
 
-    func testSentenceFormattedPreservesAcronymsAfterFirstWord() {
-        XCTAssertEqual("callbackURLScheme".sentenceFormatted, "Callback URL scheme")
+    @Test func sentenceFormattedPreservesAcronymsAfterFirstWord() {
+        #expect("callbackURLScheme".sentenceFormatted == "Callback URL scheme")
     }
 }

--- a/Tests/DCSettingsTests/StringExtendedTests.swift
+++ b/Tests/DCSettingsTests/StringExtendedTests.swift
@@ -17,7 +17,7 @@ final class StringExtendedTests: XCTestCase {
         XCTAssertEqual("great_userSetting2".sentenceFormatted, "Great user setting 2")
     }
     
-    func testSentenceFormattedTrimsLeadingWhitespaceFromAcronyms() {
+    func testSentenceFormattedFormatsAcronymCamelCaseInput() {
         XCTAssertEqual("URLScheme".sentenceFormatted, "Urlscheme")
     }
 }

--- a/Tests/DCSettingsTests/TestSupport.swift
+++ b/Tests/DCSettingsTests/TestSupport.swift
@@ -1,0 +1,26 @@
+//
+//  DCSettings
+//  Copyright (c) David Caddy 2023
+//  MIT license, see LICENSE file for details
+//
+
+import Foundation
+
+@MainActor
+func waitUntil(
+    timeout: Duration = .seconds(1),
+    pollInterval: Duration = .milliseconds(10),
+    _ condition: () -> Bool
+) async -> Bool {
+    let clock = ContinuousClock()
+    let deadline = clock.now + timeout
+
+    while clock.now < deadline {
+        if condition() {
+            return true
+        }
+        try? await Task.sleep(for: pollInterval)
+    }
+
+    return condition()
+}


### PR DESCRIPTION
This pull request updates platform support, improves option handling in settings, and refines the internal API and UI logic for the DCSettings package. The most notable changes include raising the minimum supported OS versions, enhancing option configuration for settings, improving type safety and decoding in the settings store, and updating UI components for better platform compatibility and user experience.

**Platform Support Updates:**
- Raised the minimum supported platform versions to iOS 14, macOS 11, tvOS 14, watchOS 7, and visionOS 2 in `Package.swift` and clarified these requirements in the documentation. (`Package.swift`, `DCSettings.md`) [[1]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL9-R13) [[2]](diffhunk://#diff-71c4c2edb1ef2b432f2aad2473c24ed0f2c532be7f341a5ebf6f121bd6433ac0R11-R12)

**Settings Option Handling & API Improvements:**
- Changed the way options are configured for settings: now uses a closure with `DCSettingOption` instances for better clarity and flexibility, and updated the documentation and code accordingly. (`DCSettings.md`, `DCSetting.swift`) [[1]](diffhunk://#diff-71c4c2edb1ef2b432f2aad2473c24ed0f2c532be7f341a5ebf6f121bd6433ac0L33-R38) [[2]](diffhunk://#diff-ff7b13d4c8c2b1bd8419baef7156c1fe2a459f37280bc2b7e166d71bc8cc90c1L183-R183)
- Improved the naming and documentation of parameters for clarity (e.g., `groups` to `settingGroups`). (`DCSettingsManager.swift`)

**Type Safety and Decoding Enhancements:**
- Added a new typed publisher (`valuePublisher(forKey:as:)`) and a shared decoding helper in `DCSettingStore` to ensure correct type handling and decoding of stored values, simplifying value retrieval and observation. (`DCSettingStore.swift`, `DCSetting.swift`) [[1]](diffhunk://#diff-2022494550142f03756bda11ffddc58c5512068ec3a7ea091ade226a814ae599R59-R72) [[2]](diffhunk://#diff-2022494550142f03756bda11ffddc58c5512068ec3a7ea091ade226a814ae599L78-R92) [[3]](diffhunk://#diff-2022494550142f03756bda11ffddc58c5512068ec3a7ea091ade226a814ae599R158-R170) [[4]](diffhunk://#diff-ff7b13d4c8c2b1bd8419baef7156c1fe2a459f37280bc2b7e166d71bc8cc90c1L254-R258)

**UI and Platform-Specific Improvements:**
- Refactored option controls in setting views to use a new `DCOptionControlStyle`, automatically choosing between picker and menu picker styles based on option count for a more adaptive UI. (`DCSettingView.swift`) [[1]](diffhunk://#diff-2906d1a192a0da88b07e7f4ea697c93a4541259d0eeac867ebb004b336ff9350R16-L18) [[2]](diffhunk://#diff-2906d1a192a0da88b07e7f4ea697c93a4541259d0eeac867ebb004b336ff9350L63-R77)
- Improved watchOS support: provided a custom stepper for older watchOS versions and removed unnecessary availability annotations for SwiftUI views, relying on updated platform minimums. (`DCSettingView.swift`) [[1]](diffhunk://#diff-2906d1a192a0da88b07e7f4ea697c93a4541259d0eeac867ebb004b336ff9350L102-R108) [[2]](diffhunk://#diff-2906d1a192a0da88b07e7f4ea697c93a4541259d0eeac867ebb004b336ff9350R117-R199) [[3]](diffhunk://#diff-2906d1a192a0da88b07e7f4ea697c93a4541259d0eeac867ebb004b336ff9350L46) [[4]](diffhunk://#diff-2906d1a192a0da88b07e7f4ea697c93a4541259d0eeac867ebb004b336ff9350L176) [[5]](diffhunk://#diff-2906d1a192a0da88b07e7f4ea697c93a4541259d0eeac867ebb004b336ff9350L188-R244) [[6]](diffhunk://#diff-2906d1a192a0da88b07e7f4ea697c93a4541259d0eeac867ebb004b336ff9350L205) [[7]](diffhunk://#diff-2906d1a192a0da88b07e7f4ea697c93a4541259d0eeac867ebb004b336ff9350L223) [[8]](diffhunk://#diff-2906d1a192a0da88b07e7f4ea697c93a4541259d0eeac867ebb004b336ff9350L287) [[9]](diffhunk://#diff-2906d1a192a0da88b07e7f4ea697c93a4541259d0eeac867ebb004b336ff9350L357) [[10]](diffhunk://#diff-2906d1a192a0da88b07e7f4ea697c93a4541259d0eeac867ebb004b336ff9350L393)

**Miscellaneous:**
- Fixed typos in documentation (e.g., "UserDeafults" to "UserDefaults"). (`DCSettingStore.swift`)
- Updated `Color` codable conformance to use the new Swift 6 syntax when available. (`Color+Codable.swift`)
- Removed now-unnecessary availability annotations from property wrappers, as minimum platform versions have been raised. (`DCStoredRepresentedValue.swift`, `DCStoredValue.swift`) [[1]](diffhunk://#diff-4d64e808b49044f74948068ba380fbf4366d377f13783a3fc65bdc9a8ae3d100L16) [[2]](diffhunk://#diff-e0f0b172fb00a6beb2a2a54c4eef975cee065f315a76dfd65bf0763d7614f457L23)